### PR TITLE
Issue 66

### DIFF
--- a/allel/chunked/core.py
+++ b/allel/chunked/core.py
@@ -142,6 +142,13 @@ def reduce_axis(data, reducer, block_reducer, mapper=None, axis=None,
     if isinstance(axis, int):
         axis = (axis,)
 
+    # deal with 'out' kwarg if supplied, can arise if a chunked array is
+    # passed as an argument to numpy.sum(), see also
+    # https://github.com/cggh/scikit-allel/issues/66
+    kwarg_out = kwargs.pop('out', None)
+    if kwarg_out is not None:
+        raise ValueError('keyword argument "out" is not supported')
+
     if axis is None or 0 in axis:
         # two-step reduction
         out = None

--- a/allel/model/bcolz.py
+++ b/allel/model/bcolz.py
@@ -780,11 +780,17 @@ class CArrayWrapper(object):
         else:
             raise ValueError('rootdir does not contain a carray')
 
-    def max(self, axis=None):
-        return carray_block_max(self.carr, axis=axis)
+    def max(self, axis=None, blen=None, **kwargs):
+        # ignore any other kwargs
+        return carray_block_max(self.carr, axis=axis, blen=blen)
 
-    def min(self, axis=None):
-        return carray_block_min(self.carr, axis=axis)
+    def min(self, axis=None, blen=None, **kwargs):
+        # ignore any other kwargs
+        return carray_block_min(self.carr, axis=axis, blen=blen)
+
+    def sum(self, axis=None, blen=None, **kwargs):
+        # ignore any other kwargs
+        return carray_block_sum(self.carr, axis=axis, blen=blen)
 
     def op_scalar(self, op, other, **kwargs):
         if not np.isscalar(other):

--- a/allel/test/test_model_bcolz.py
+++ b/allel/test/test_model_bcolz.py
@@ -198,6 +198,33 @@ class GenotypeCArrayTests(GenotypeArrayInterface, unittest.TestCase):
         with assert_raises(ValueError):
             g.take(indices, axis=0)
 
+    def test_to_n_ref_array_like(self):
+        # see also https://github.com/cggh/scikit-allel/issues/66
+
+        gn = self.setup_instance(diploid_genotype_data).to_n_ref(fill=-1)
+        t = gn > 0
+        eq(4, np.count_nonzero(t))
+        expect = np.array([[1, 1, 0],
+                           [1, 0, 0],
+                           [1, 0, 0],
+                           [0, 0, 0],
+                           [0, 0, 0]], dtype='b1')
+        aeq(expect, t)
+
+        # numpy reductions trigger the issue
+
+        expect = np.array([2, 1, 1, 0, 0])
+        actual = np.sum(t, axis=1)
+        aeq(expect, actual)
+
+        expect = np.array([0, 0, 0, 0, 0])
+        actual = np.min(t, axis=1)
+        aeq(expect, actual)
+
+        expect = np.array([1, 1, 1, 0, 0])
+        actual = np.max(t, axis=1)
+        aeq(expect, actual)
+
 
 class HaplotypeCArrayTests(HaplotypeArrayInterface, unittest.TestCase):
 

--- a/allel/test/test_model_chunked.py
+++ b/allel/test/test_model_chunked.py
@@ -124,6 +124,33 @@ class GenotypeChunkedArrayTests(GenotypeArrayInterface, unittest.TestCase):
         with assert_raises(NotImplementedError):
             g.take(indices, axis=0)
 
+    def test_to_n_ref_array_like(self):
+        # see also https://github.com/cggh/scikit-allel/issues/66
+
+        gn = self.setup_instance(diploid_genotype_data).to_n_ref(fill=-1)
+        t = gn > 0
+        eq(4, np.count_nonzero(t))
+        expect = np.array([[1, 1, 0],
+                           [1, 0, 0],
+                           [1, 0, 0],
+                           [0, 0, 0],
+                           [0, 0, 0]], dtype='b1')
+        aeq(expect, t)
+
+        # numpy reductions trigger the issue
+
+        expect = np.array([2, 1, 1, 0, 0])
+        actual = np.sum(t, axis=1)
+        aeq(expect, actual)
+
+        expect = np.array([0, 0, 0, 0, 0])
+        actual = np.min(t, axis=1)
+        aeq(expect, actual)
+
+        expect = np.array([1, 1, 1, 0, 0])
+        actual = np.max(t, axis=1)
+        aeq(expect, actual)
+
 
 class GenotypeChunkedArrayTestsBColzTmpStorage(GenotypeChunkedArrayTests):
 

--- a/docs/release.rst
+++ b/docs/release.rst
@@ -1,6 +1,10 @@
 Release notes
 =============
 
+* Added workaround for chunked arrays if passed as arguments into numpy
+  aggregation functions
+  (`#66 <https://github.com/cggh/scikit-allel/issues/66>`_).
+
 v0.20.3
 -------
 


### PR DESCRIPTION
This PR makes a small change to work around the behaviour of numpy reductions (sum, min, max) if a chunked array is passed as an argument. If the argument is not an array but has a "sum/min/max" method then numpy delegates the call to that, expecting exactly the same call signature. As part of this it passed through ``out=None`` which should be handled.