### PR TITLE
Bugfix for field with TYPE=CHARACTER.

### DIFF
--- a/allel/io/vcf_read.py
+++ b/allel/io/vcf_read.py
@@ -1189,7 +1189,7 @@ def _normalize_type(t):
         return np.dtype(default_integer_dtype)
     elif t == 'Float':
         return np.dtype(default_float_dtype)
-    elif t == 'String':
+    elif t == 'String' or t == 'Character':
         return np.dtype(default_string_dtype)
     elif t == 'Flag':
         return np.dtype(bool)


### PR DESCRIPTION
Simple bug fix for TYPE=Character in the VCF.

Note that VCF Spec v4.3 lists a TYPE=Character on p.4 https://samtools.github.io/hts-specs/VCFv4.3.pdf 

Relevant Text:
1.3 Data types
Data types supported by VCF are: Integer (32-bit, signed), Float (32-bit, formatted to match the regular expression
^[-+]?[0-9]*\.?[0-9]+([eE][-+]?[0-9]+)?$, NaN, or +/-Inf), Flag, **Character**, and String. 

Closes #159 

