### PR TITLE
Mitigate name clashes on case-insensitive platforms when using vcf_to_zarr

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -65,6 +65,7 @@ example.*
 *.npz
 profdata/*
 temp/*
+allel/version.py
 
 # setuptools-scm
 allel/version.py

--- a/allel/io/vcf_read.py
+++ b/allel/io/vcf_read.py
@@ -22,6 +22,7 @@ import numpy as np
 from allel.compat import PY2, FileNotFoundError, text_type
 from allel.opt.io_vcf_read import VCFChunkIterator, FileInputStream
 # expose some names from cython extension
+# noinspection PyUnresolvedReferences
 from allel.opt.io_vcf_read import (  # noqa: F401
     ANNTransformer, ANN_AA_LENGTH_FIELD, ANN_AA_POS_FIELD, ANN_ANNOTATION_FIELD,
     ANN_ANNOTATION_IMPACT_FIELD, ANN_CDNA_LENGTH_FIELD, ANN_CDNA_POS_FIELD, ANN_CDS_LENGTH_FIELD,
@@ -118,6 +119,9 @@ _doc_param_fields = \
         (including all INFO fields) provide ``'variants/*'``. To extract all calldata fields (i.e.,
         defined in FORMAT headers) provide ``'calldata/*'``."""
 
+_doc_param_exclude_fields = \
+    """Fields to exclude. E.g., for use in combination with ``fields='*'``."""
+
 _doc_param_types = \
     """Overide data types. Should be a dictionary mapping field names to NumPy data types.
         E.g., providing the dictionary ``{'variants/DP': 'i8', 'calldata/GQ': 'i2'}`` will mean
@@ -178,6 +182,7 @@ _doc_param_log = \
 
 def read_vcf(input,
              fields=None,
+             exclude_fields=None,
              types=None,
              numbers=None,
              alt_number=DEFAULT_ALT_NUMBER,
@@ -197,6 +202,8 @@ def read_vcf(input,
         {input}
     fields : list of strings, optional
         {fields}
+    exclude_fields : list of strings, optional
+        {exclude_fields}
     types : dict, optional
         {types}
     numbers : dict, optional
@@ -233,9 +240,10 @@ def read_vcf(input,
 
     # setup
     _, samples, _, it = iter_vcf_chunks(
-        input=input, fields=fields, types=types, numbers=numbers, alt_number=alt_number,
-        buffer_size=buffer_size, chunk_length=chunk_length, fills=fills, region=region,
-        tabix=tabix, samples=samples, transformers=transformers
+        input=input, fields=fields, exclude_fields=exclude_fields, types=types,
+        numbers=numbers, alt_number=alt_number, buffer_size=buffer_size,
+        chunk_length=chunk_length, fills=fills, region=region, tabix=tabix,
+        samples=samples, transformers=transformers
     )
 
     # setup progress logging
@@ -266,6 +274,7 @@ def read_vcf(input,
 read_vcf.__doc__ = read_vcf.__doc__.format(
     input=_doc_param_input,
     fields=_doc_param_fields,
+    exclude_fields=_doc_param_exclude_fields,
     types=_doc_param_types,
     numbers=_doc_param_numbers,
     alt_number=_doc_param_alt_number,
@@ -291,6 +300,7 @@ def vcf_to_npz(input, output,
                compressed=True,
                overwrite=False,
                fields=None,
+               exclude_fields=None,
                types=None,
                numbers=None,
                alt_number=DEFAULT_ALT_NUMBER,
@@ -316,6 +326,8 @@ def vcf_to_npz(input, output,
         {overwrite}
     fields : list of strings, optional
         {fields}
+    exclude_fields : list of strings, optional
+        {exclude_fields}
     types : dict, optional
         {types}
     numbers : dict, optional
@@ -347,9 +359,10 @@ def vcf_to_npz(input, output,
 
     # read all data into memory
     data = read_vcf(
-        input=input, fields=fields, types=types, numbers=numbers, alt_number=alt_number,
-        buffer_size=buffer_size, chunk_length=chunk_length, log=log, fills=fills,
-        region=region, tabix=tabix, samples=samples, transformers=transformers
+        input=input, fields=fields, exclude_fields=exclude_fields, types=types,
+        numbers=numbers, alt_number=alt_number, buffer_size=buffer_size,
+        chunk_length=chunk_length, log=log, fills=fills, region=region, tabix=tabix,
+        samples=samples, transformers=transformers
     )
 
     # setup save function
@@ -367,6 +380,7 @@ vcf_to_npz.__doc__ = vcf_to_npz.__doc__.format(
     output=_doc_param_output,
     overwrite=_doc_param_overwrite,
     fields=_doc_param_fields,
+    exclude_fields=_doc_param_exclude_fields,
     types=_doc_param_types,
     numbers=_doc_param_numbers,
     alt_number=_doc_param_alt_number,
@@ -489,6 +503,7 @@ def vcf_to_hdf5(input, output,
                 overwrite=False,
                 vlen=True,
                 fields=None,
+                exclude_fields=None,
                 types=None,
                 numbers=None,
                 alt_number=DEFAULT_ALT_NUMBER,
@@ -531,6 +546,8 @@ def vcf_to_hdf5(input, output,
         you know at most 10 characters are required.
     fields : list of strings, optional
         {fields}
+    exclude_fields : list of strings, optional
+        {exclude_fields}
     types : dict, optional
         {types}
     numbers : dict, optional
@@ -575,9 +592,10 @@ def vcf_to_hdf5(input, output,
 
         # setup chunk iterator
         _, samples, headers, it = iter_vcf_chunks(
-            input, fields=fields, types=types, numbers=numbers, alt_number=alt_number,
-            buffer_size=buffer_size, chunk_length=chunk_length, fills=fills, region=region,
-            tabix=tabix, samples=samples, transformers=transformers
+            input, fields=fields, exclude_fields=exclude_fields, types=types,
+            numbers=numbers, alt_number=alt_number, buffer_size=buffer_size,
+            chunk_length=chunk_length, fills=fills, region=region, tabix=tabix,
+            samples=samples, transformers=transformers
         )
 
         # setup progress logging
@@ -628,6 +646,7 @@ vcf_to_hdf5.__doc__ = vcf_to_hdf5.__doc__.format(
     output=_doc_param_output,
     overwrite=_doc_param_overwrite,
     fields=_doc_param_fields,
+    exclude_fields=_doc_param_exclude_fields,
     types=_doc_param_types,
     numbers=_doc_param_numbers,
     alt_number=_doc_param_alt_number,
@@ -704,6 +723,7 @@ def vcf_to_zarr(input, output,
                 compressor='default',
                 overwrite=False,
                 fields=None,
+                exclude_fields=None,
                 types=None,
                 numbers=None,
                 alt_number=DEFAULT_ALT_NUMBER,
@@ -732,6 +752,8 @@ def vcf_to_zarr(input, output,
         {overwrite}
     fields : list of strings, optional
         {fields}
+    exclude_fields : list of strings, optional
+        {exclude_fields}
     types : dict, optional
         {types}
     numbers : dict, optional
@@ -774,9 +796,10 @@ def vcf_to_zarr(input, output,
 
     # setup chunk iterator
     _, samples, headers, it = iter_vcf_chunks(
-        input, fields=fields, types=types, numbers=numbers, alt_number=alt_number,
-        buffer_size=buffer_size, chunk_length=chunk_length, fills=fills, region=region,
-        tabix=tabix, samples=samples, transformers=transformers
+        input, fields=fields, exclude_fields=exclude_fields, types=types,
+        numbers=numbers, alt_number=alt_number, buffer_size=buffer_size,
+        chunk_length=chunk_length, fills=fills, region=region, tabix=tabix,
+        samples=samples, transformers=transformers
     )
 
     # setup progress logging
@@ -819,6 +842,7 @@ vcf_to_zarr.__doc__ = vcf_to_zarr.__doc__.format(
     output=_doc_param_output,
     overwrite=_doc_param_overwrite,
     fields=_doc_param_fields,
+    exclude_fields=_doc_param_exclude_fields,
     types=_doc_param_types,
     numbers=_doc_param_numbers,
     alt_number=_doc_param_alt_number,
@@ -836,6 +860,7 @@ vcf_to_zarr.__doc__ = vcf_to_zarr.__doc__.format(
 
 def iter_vcf_chunks(input,
                     fields=None,
+                    exclude_fields=None,
                     types=None,
                     numbers=None,
                     alt_number=DEFAULT_ALT_NUMBER,
@@ -854,6 +879,8 @@ def iter_vcf_chunks(input,
         {input}
     fields : list of strings, optional
         {fields}
+    exclude_fields : list of strings, optional
+        {exclude_fields}
     types : dict, optional
         {types}
     numbers : dict, optional
@@ -889,8 +916,9 @@ def iter_vcf_chunks(input,
     """
 
     # setup commmon keyword args
-    kwds = dict(fields=fields, types=types, numbers=numbers, alt_number=alt_number,
-                chunk_length=chunk_length, fills=fills, samples=samples)
+    kwds = dict(fields=fields, exclude_fields=exclude_fields, types=types,
+                numbers=numbers, alt_number=alt_number, chunk_length=chunk_length,
+                fills=fills, samples=samples)
 
     # obtain a file-like object
     close = False
@@ -971,6 +999,7 @@ def iter_vcf_chunks(input,
 iter_vcf_chunks.__doc__ = iter_vcf_chunks.__doc__.format(
     input=_doc_param_input,
     fields=_doc_param_fields,
+    exclude_fields=_doc_param_exclude_fields,
     types=_doc_param_types,
     numbers=_doc_param_numbers,
     alt_number=_doc_param_alt_number,
@@ -1439,8 +1468,8 @@ def _normalize_samples(samples, headers, types):
     return normed_samples, loc_samples
 
 
-def _iter_vcf_stream(stream, fields, types, numbers, alt_number, chunk_length, fills, region,
-                     samples):
+def _iter_vcf_stream(stream, fields, exclude_fields, types, numbers, alt_number,
+                     chunk_length, fills, region, samples):
 
     # read VCF headers
     headers = _read_vcf_headers(stream)
@@ -1460,6 +1489,12 @@ def _iter_vcf_stream(stream, fields, types, numbers, alt_number, chunk_length, f
 
     else:
         fields = _normalize_fields(fields=fields, headers=headers, samples=samples)
+
+    # deal with field exclusions
+    if exclude_fields:
+        exclude_fields = _normalize_fields(fields=exclude_fields, headers=headers,
+                                           samples=samples)
+        fields = [f for f in fields if f not in exclude_fields]
 
     # setup data types
     types = _normalize_types(types=types, fields=fields, headers=headers)
@@ -1578,11 +1613,14 @@ def _chunk_to_dataframe(fields, chunk):
         else:
             warnings.warn('cannot handle array %r with >2 dimensions, skipping' % name)
     df = pandas.DataFrame.from_items(items)
+    # treat empty string as missing
+    df.replace('', np.nan, inplace=True)
     return df
 
 
 def vcf_to_dataframe(input,
                      fields=None,
+                     exclude_fields=None,
                      types=None,
                      numbers=None,
                      alt_number=DEFAULT_ALT_NUMBER,
@@ -1601,6 +1639,8 @@ def vcf_to_dataframe(input,
         {input}
     fields : list of strings, optional
         {fields}
+    exclude_fields : list of strings, optional
+        {exclude_fields}
     types : dict, optional
         {types}
     numbers : dict, optional
@@ -1636,9 +1676,10 @@ def vcf_to_dataframe(input,
 
     # setup
     fields, _, _, it = iter_vcf_chunks(
-        input=input, fields=fields, types=types, numbers=numbers, alt_number=alt_number,
-        buffer_size=buffer_size, chunk_length=chunk_length, fills=fills, region=region,
-        tabix=tabix, samples=[], transformers=transformers
+        input=input, fields=fields, exclude_fields=exclude_fields, types=types,
+        numbers=numbers, alt_number=alt_number, buffer_size=buffer_size,
+        chunk_length=chunk_length, fills=fills, region=region, tabix=tabix, samples=[],
+        transformers=transformers
     )
 
     # setup progress logging
@@ -1663,6 +1704,7 @@ def vcf_to_dataframe(input,
 vcf_to_dataframe.__doc__ = vcf_to_dataframe.__doc__.format(
     input=_doc_param_input,
     fields=_doc_param_fields,
+    exclude_fields=_doc_param_exclude_fields,
     types=_doc_param_types,
     numbers=_doc_param_numbers,
     alt_number=_doc_param_alt_number,
@@ -1678,6 +1720,7 @@ vcf_to_dataframe.__doc__ = vcf_to_dataframe.__doc__.format(
 
 def vcf_to_csv(input, output,
                fields=None,
+               exclude_fields=None,
                types=None,
                numbers=None,
                alt_number=DEFAULT_ALT_NUMBER,
@@ -1699,6 +1742,8 @@ def vcf_to_csv(input, output,
         {output}
     fields : list of strings, optional
         {fields}
+    exclude_fields : list of strings, optional
+        {exclude_fields}
     types : dict, optional
         {types}
     numbers : dict, optional
@@ -1731,9 +1776,10 @@ def vcf_to_csv(input, output,
 
     # setup
     fields, _, _, it = iter_vcf_chunks(
-        input=input, fields=fields, types=types, numbers=numbers, alt_number=alt_number,
-        buffer_size=buffer_size, chunk_length=chunk_length, fills=fills, region=region, tabix=tabix,
-        samples=[], transformers=transformers
+        input=input, fields=fields, exclude_fields=exclude_fields, types=types,
+        numbers=numbers, alt_number=alt_number, buffer_size=buffer_size,
+        chunk_length=chunk_length, fills=fills, region=region, tabix=tabix, samples=[],
+        transformers=transformers
     )
 
     # setup progress logging
@@ -1756,6 +1802,7 @@ vcf_to_csv.__doc__ = vcf_to_csv.__doc__.format(
     input=_doc_param_input,
     output=_doc_param_output,
     fields=_doc_param_fields,
+    exclude_fields=_doc_param_exclude_fields,
     types=_doc_param_types,
     numbers=_doc_param_numbers,
     alt_number=_doc_param_alt_number,
@@ -1790,6 +1837,7 @@ def _chunk_to_recarray(fields, chunk):
 
 def vcf_to_recarray(input,
                     fields=None,
+                    exclude_fields=None,
                     types=None,
                     numbers=None,
                     alt_number=DEFAULT_ALT_NUMBER,
@@ -1808,6 +1856,8 @@ def vcf_to_recarray(input,
         {input}
     fields : list of strings, optional
         {fields}
+    exclude_fields : list of strings, optional
+        {exclude_fields}
     types : dict, optional
         {types}
     numbers : dict, optional
@@ -1842,9 +1892,10 @@ def vcf_to_recarray(input,
     # setup chunk iterator
     # N.B., set samples to empty list so we don't get any calldata fields
     fields, _, _, it = iter_vcf_chunks(
-        input=input, fields=fields, types=types, numbers=numbers, alt_number=alt_number,
-        buffer_size=buffer_size, chunk_length=chunk_length, fills=fills, region=region,
-        tabix=tabix, samples=[], transformers=transformers
+        input=input, fields=fields, exclude_fields=exclude_fields, types=types,
+        numbers=numbers, alt_number=alt_number, buffer_size=buffer_size,
+        chunk_length=chunk_length, fills=fills, region=region, tabix=tabix, samples=[],
+        transformers=transformers
     )
 
     # setup progress logging
@@ -1868,6 +1919,7 @@ def vcf_to_recarray(input,
 vcf_to_recarray.__doc__ = vcf_to_recarray.__doc__.format(
     input=_doc_param_input,
     fields=_doc_param_fields,
+    exclude_fields=_doc_param_exclude_fields,
     types=_doc_param_types,
     numbers=_doc_param_numbers,
     alt_number=_doc_param_alt_number,

--- a/allel/io/vcf_read.py
+++ b/allel/io/vcf_read.py
@@ -2,8 +2,8 @@
 """
 Extract data from VCF files.
 
-This module contains Functions for extracting data from Variant Call Format (VCF) files and loading
-into NumPy arrays, NumPy files, HDF5 files or Zarr array stores.
+This module contains Functions for extracting data from Variant Call Format (VCF) files
+and loading into NumPy arrays, NumPy files, HDF5 files or Zarr array stores.
 
 """
 from __future__ import absolute_import, print_function, division
@@ -27,10 +27,11 @@ from allel.opt.io_vcf_read import VCFChunkIterator, FileInputStream
 # noinspection PyUnresolvedReferences
 from allel.opt.io_vcf_read import (  # noqa: F401
     ANNTransformer, ANN_AA_LENGTH_FIELD, ANN_AA_POS_FIELD, ANN_ANNOTATION_FIELD,
-    ANN_ANNOTATION_IMPACT_FIELD, ANN_CDNA_LENGTH_FIELD, ANN_CDNA_POS_FIELD, ANN_CDS_LENGTH_FIELD,
-    ANN_CDS_POS_FIELD, ANN_DISTANCE_FIELD, ANN_FEATURE_ID_FIELD, ANN_FEATURE_TYPE_FIELD, ANN_FIELD,
-    ANN_FIELDS, ANN_GENE_ID_FIELD, ANN_GENE_NAME_FIELD, ANN_HGVS_C_FIELD, ANN_HGVS_P_FIELD,
-    ANN_RANK_FIELD, ANN_TRANSCRIPT_BIOTYPE_FIELD
+    ANN_ANNOTATION_IMPACT_FIELD, ANN_CDNA_LENGTH_FIELD, ANN_CDNA_POS_FIELD,
+    ANN_CDS_LENGTH_FIELD, ANN_CDS_POS_FIELD, ANN_DISTANCE_FIELD, ANN_FEATURE_ID_FIELD,
+    ANN_FEATURE_TYPE_FIELD, ANN_FIELD, ANN_FIELDS, ANN_GENE_ID_FIELD,
+    ANN_GENE_NAME_FIELD, ANN_HGVS_C_FIELD, ANN_HGVS_P_FIELD, ANN_RANK_FIELD,
+    ANN_TRANSCRIPT_BIOTYPE_FIELD
 )
 
 
@@ -83,7 +84,8 @@ def _chunk_iter_progress(it, log, prefix):
         chrom = text_type(chrom, 'utf8')
         message = (
             '%s %s rows in %.2fs; chunk in %.2fs (%s rows/s)' %
-            (prefix, n_variants, elapsed, elapsed_chunk, int(chunk_length // elapsed_chunk))
+            (prefix, n_variants, elapsed, elapsed_chunk,
+             int(chunk_length // elapsed_chunk))
         )
         if chrom:
             message += '; %s:%s' % (chrom, pos)
@@ -138,15 +140,16 @@ _doc_param_input = \
 
 _doc_param_fields = \
     """Fields to extract data for. Should be a list of strings, e.g., ``['variants/CHROM',
-        'variants/POS', 'variants/DP', 'calldata/GT']``. If you are feeling lazy, you can drop
-        the 'variants/' and 'calldata/' prefixes, in which case the fields will be matched against
-        fields declared in the VCF header, with variants taking priority over calldata if a field
-        with the same ID exists both in INFO and FORMAT headers. I.e., ``['CHROM', 'POS', 'DP',
-        'GT']`` will work, although watch out for fields like 'DP' which can be both
-        INFO and FORMAT. For convenience, some special string values are also recognized. To
-        extract all fields, provide just the string ``'*'``. To extract all variants fields
-        (including all INFO fields) provide ``'variants/*'``. To extract all calldata fields (i.e.,
-        defined in FORMAT headers) provide ``'calldata/*'``."""
+        'variants/POS', 'variants/DP', 'calldata/GT']``. If you are feeling lazy, 
+        you can drop the 'variants/' and 'calldata/' prefixes, in which case the fields 
+        will be matched against fields declared in the VCF header, with variants taking 
+        priority over calldata if a field with the same ID exists both in INFO and 
+        FORMAT headers. I.e., ``['CHROM', 'POS', 'DP', 'GT']`` will work, although 
+        watch out for fields like 'DP' which can be both INFO and FORMAT. For 
+        convenience, some special string values are also recognized. To extract all 
+        fields, provide just the string ``'*'``. To extract all variants fields 
+        (including all INFO fields) provide ``'variants/*'``. To extract all calldata 
+        fields (i.e., defined in FORMAT headers) provide ``'calldata/*'``."""
 
 _doc_param_exclude_fields = \
     """Fields to exclude. E.g., for use in combination with ``fields='*'``."""
@@ -157,54 +160,59 @@ _doc_param_rename_fields = \
 
 _doc_param_types = \
     """Overide data types. Should be a dictionary mapping field names to NumPy data types.
-        E.g., providing the dictionary ``{'variants/DP': 'i8', 'calldata/GQ': 'i2'}`` will mean
-        the 'variants/DP' field is stored in a 64-bit integer array, and the 'calldata/GQ' field
-        is stored in a 16-bit integer array."""
+        E.g., providing the dictionary ``{'variants/DP': 'i8', 'calldata/GQ': 'i2'}`` will 
+        mean the 'variants/DP' field is stored in a 64-bit integer array, and the 
+        'calldata/GQ' field is stored in a 16-bit integer array."""
 
 _doc_param_numbers = \
-    """Override the expected number of values. Should be a dictionary mapping field names to
-        integers. E.g., providing the dictionary ``{'variants/ALT': 5, 'variants/AC': 5,
-        'calldata/HQ': 2}`` will mean that, for each variant, 5 values are stored for the
-        'variants/ALT' field, 5 values are stored for the 'variants/AC' field, and for each
-        sample, 2 values are stored for the 'calldata/HQ' field."""
+    """Override the expected number of values. Should be a dictionary mapping field names 
+        to integers. E.g., providing the dictionary ``{'variants/ALT': 5, 
+        'variants/AC': 5, 'calldata/HQ': 2}`` will mean that, for each variant, 5 values 
+        are stored for the 'variants/ALT' field, 5 values are stored for the 
+        'variants/AC' field, and for each sample, 2 values are stored for the 
+        'calldata/HQ' field."""
 
 _doc_param_alt_number = \
-    """Assume this number of alternate alleles and set expected number of values accordingly for
-        any field declared with number 'A' or 'R' in the VCF meta-information."""
+    """Assume this number of alternate alleles and set expected number of values 
+        accordingly for any field declared with number 'A' or 'R' in the VCF 
+        meta-information."""
 
 _doc_param_fills = \
-    """Override the fill value used for empty values. Should be a dictionary mapping field names
-        to fill values."""
+    """Override the fill value used for empty values. Should be a dictionary mapping 
+        field names to fill values."""
 
 _doc_param_region = \
-    """Genomic region to extract variants for. If provided, should be a tabix-style region string,
-        which can be either just a chromosome name (e.g., '2L'), or a chromosome name followed by
-        1-based beginning and end coordinates (e.g., '2L:100000-200000'). Note that only variants
-        whose start position (POS) is within the requested range will be included. This is slightly
-        different from the default tabix behaviour, where a variant (e.g., deletion) may be included
-        if its position (POS) occurs before the requested region but its reference allele overlaps
-        the region - such a variant will *not* be included in the data returned by this function."""
+    """Genomic region to extract variants for. If provided, should be a tabix-style 
+        region string, which can be either just a chromosome name (e.g., '2L'), 
+        or a chromosome name followed by 1-based beginning and end coordinates (e.g., 
+        '2L:100000-200000'). Note that only variants whose start position (POS) is 
+        within the requested range will be included. This is slightly different from 
+        the default tabix behaviour, where a variant (e.g., deletion) may be included 
+        if its position (POS) occurs before the requested region but its reference allele 
+        overlaps the region - such a variant will *not* be included in the data 
+        returned by this function."""
 
 _doc_param_tabix = \
-    """Name or path to tabix executable. Only required if `region` is given. Setting `tabix` to
-        `None` will cause a fall-back to scanning through the VCF file from the beginning, which
-        may be much slower than tabix but the only option if tabix is not available on your system
-        and/or the VCF file has not been tabix-indexed."""
+    """Name or path to tabix executable. Only required if `region` is given. Setting 
+        `tabix` to `None` will cause a fall-back to scanning through the VCF file from 
+        the beginning, which may be much slower than tabix but the only option if tabix 
+        is not available on your system and/or the VCF file has not been tabix-indexed."""
 
 _doc_param_samples = \
-    """Selection of samples to extract calldata for. If provided, should be a list of strings
-        giving sample identifiers. May also be a list of integers giving indices of selected
-        samples."""
+    """Selection of samples to extract calldata for. If provided, should be a list of 
+        strings giving sample identifiers. May also be a list of integers giving 
+        indices of selected samples."""
 
 _doc_param_transformers = \
     """Transformers for post-processing data. If provided, should be a list of Transformer
         objects, each of which must implement a "transform()" method that accepts a dict
-        containing the chunk of data to be transformed. See also the :class:`ANNTransformer`
-        class which implements post-processing of data from SNPEFF."""
+        containing the chunk of data to be transformed. See also the 
+        :class:`ANNTransformer` class which implements post-processing of data from 
+        SNPEFF."""
 
 _doc_param_buffer_size = \
-    """Size in bytes of the I/O buffer used when reading data from the underlying file or tabix
-        stream."""
+    """Size in bytes of the I/O buffer used when reading data from the underlying file or 
+        tabix stream."""
 
 _doc_param_chunk_length = \
     """Length (number of variants) of chunks in which data are processed."""
@@ -213,6 +221,7 @@ _doc_param_log = \
     """A file-like object (e.g., `sys.stderr`) to print progress information."""
 
 
+# noinspection PyShadowingBuiltins
 def read_vcf(input,
              fields=None,
              exclude_fields=None,
@@ -339,6 +348,7 @@ _doc_param_overwrite = \
     """If False (default), do not overwrite an existing file."""
 
 
+# noinspection PyShadowingBuiltins
 def vcf_to_npz(input, output,
                compressed=True,
                overwrite=False,
@@ -443,8 +453,8 @@ vcf_to_npz.__doc__ = vcf_to_npz.__doc__.format(
 )
 
 
-def _hdf5_setup_datasets(chunk, root, chunk_length, chunk_width, compression, compression_opts,
-                         shuffle, overwrite, headers, vlen):
+def _hdf5_setup_datasets(chunk, root, chunk_length, chunk_width, compression,
+                         compression_opts, shuffle, overwrite, headers, vlen):
     import h5py
 
     # handle no input
@@ -531,9 +541,10 @@ def _hdf5_store_chunk(root, keys, chunk, vlen):
             data = data.astype('S')
             if data.dtype.itemsize > dataset.dtype.itemsize:
                 warnings.warn(
-                    'found string length %s longer than %s guessed for field %r, values will be '
-                    'truncated; recommend rerunning setting type to at least "S%s"' %
-                    (data.dtype.itemsize, dataset.dtype.itemsize, k, data.dtype.itemsize)
+                    'found string length %s longer than %s guessed for field %r, values '
+                    'will be truncated; recommend rerunning, setting type to at least '
+                    '"S%s"' % (data.dtype.itemsize, dataset.dtype.itemsize, k,
+                               data.dtype.itemsize)
                 )
 
         # ensure dataset is long enough
@@ -547,6 +558,7 @@ _doc_param_chunk_width = \
     """Width (number of samples) to use when storing chunks in output."""
 
 
+# noinspection PyShadowingBuiltins
 def vcf_to_hdf5(input, output,
                 group='/',
                 compression='gzip',
@@ -588,15 +600,16 @@ def vcf_to_hdf5(input, output,
     overwrite : bool
         {overwrite}
     vlen : bool
-        If True, store variable length strings. Note that there is considerable storage overhead
-        for variable length strings in HDF5, and leaving this option as True (default) may lead
-        to large file sizes. If False, all strings will be stored in the HDF5 file as fixed length
-        strings, even if they are specified as 'object' type. In this case, the string length for
-        any field with 'object' type will be determined based on the maximum length of strings
-        found in the first chunk, and this may cause values to be truncated if longer values are
-        found in later chunks. To avoid truncation and large file sizes, manually set the type for
-        all string fields to an explicit fixed length string type, e.g., 'S10' for a field where
-        you know at most 10 characters are required.
+        If True, store variable length strings. Note that there is considerable storage
+        overhead for variable length strings in HDF5, and leaving this option as True (
+        default) may lead to large file sizes. If False, all strings will be stored in
+        the HDF5 file as fixed length strings, even if they are specified as 'object'
+        type. In this case, the string length for any field with 'object' type will be
+        determined based on the maximum length of strings found in the first chunk,
+        and this may cause values to be truncated if longer values are found in later
+        chunks. To avoid truncation and large file sizes, manually set the type for all
+        string fields to an explicit fixed length string type, e.g., 'S10' for a field
+        where you know at most 10 characters are required.
     fields : list of strings, optional
         {fields}
     exclude_fields : list of strings, optional
@@ -720,7 +733,8 @@ vcf_to_hdf5.__doc__ = vcf_to_hdf5.__doc__.format(
 )
 
 
-def _zarr_setup_datasets(chunk, root, chunk_length, chunk_width, compressor, overwrite, headers):
+def _zarr_setup_datasets(chunk, root, chunk_length, chunk_width, compressor, overwrite,
+                         headers):
 
     # handle no input
     if chunk is None:
@@ -776,6 +790,7 @@ def _zarr_store_chunk(root, keys, chunk):
         root[k].append(chunk[k], axis=0)
 
 
+# noinspection PyShadowingBuiltins
 def vcf_to_zarr(input, output,
                 group='/',
                 compressor='default',
@@ -905,8 +920,8 @@ def vcf_to_zarr(input, output,
     # setup datasets
     # noinspection PyTypeChecker
     keys = _zarr_setup_datasets(
-        chunk, root=root, chunk_length=chunk_length, chunk_width=chunk_width, compressor=compressor,
-        overwrite=overwrite, headers=headers
+        chunk, root=root, chunk_length=chunk_length, chunk_width=chunk_width,
+        compressor=compressor, overwrite=overwrite, headers=headers
     )
 
     # store first chunk
@@ -940,6 +955,68 @@ vcf_to_zarr.__doc__ = vcf_to_zarr.__doc__.format(
 )
 
 
+# noinspection PyShadowingBuiltins
+def _setup_input_stream(input, region=None, tabix=None, buffer_size=DEFAULT_BUFFER_SIZE):
+
+    # obtain a file-like object
+    close = False
+    if isinstance(input, str) and input.endswith('gz'):
+
+        if region and tabix and os.name != 'nt':
+
+            try:
+                # try tabix
+                p = subprocess.Popen([tabix, '-h', input, region],
+                                     stdout=subprocess.PIPE,
+                                     stderr=subprocess.STDOUT,
+                                     bufsize=0)
+
+                # check if tabix exited early, look for tabix error
+                time.sleep(.5)
+                poll = p.poll()
+                if poll is not None and poll > 0:
+                    err = p.stdout.read()
+                    if not PY2:
+                        err = str(err, 'ascii')
+                    p.stdout.close()
+                    raise RuntimeError(err.strip())
+                fileobj = p.stdout
+                close = True
+                # N.B., still pass the region parameter through so we get strictly only
+                # variants that start within the requested region. See also
+                # https://github.com/alimanfoo/vcfnp/issues/54
+
+            except FileNotFoundError:
+                # no tabix, fall back to scanning
+                warnings.warn('tabix not found, falling back to scanning to region')
+                fileobj = gzip.open(input, mode='rb')
+                close = True
+
+            except Exception as e:
+                warnings.warn('error occurred attempting tabix (%s); falling back to '
+                              'scanning to region' % e)
+                fileobj = gzip.open(input, mode='rb')
+                close = True
+
+        else:
+            fileobj = gzip.open(input, mode='rb')
+            close = True
+
+    elif isinstance(input, str):
+        # assume no compression
+        fileobj = open(input, mode='rb', buffering=0)
+        close = True
+
+    elif hasattr(input, 'readinto'):
+        fileobj = input
+
+    else:
+        raise ValueError('path must be string or file-like, found %r' % input)
+
+    return FileInputStream(fileobj, buffer_size=buffer_size, close=close)
+
+
+# noinspection PyShadowingBuiltins
 def iter_vcf_chunks(input,
                     fields=None,
                     exclude_fields=None,
@@ -1000,68 +1077,11 @@ def iter_vcf_chunks(input,
     # setup commmon keyword args
     kwds = dict(fields=fields, exclude_fields=exclude_fields, types=types,
                 numbers=numbers, alt_number=alt_number, chunk_length=chunk_length,
-                fills=fills, samples=samples)
-
-    # obtain a file-like object
-    close = False
-    if isinstance(input, str) and input.endswith('gz'):
-
-        if region and tabix and os.name != 'nt':
-
-            try:
-                # try tabix
-                p = subprocess.Popen([tabix, '-h', input, region],
-                                     stdout=subprocess.PIPE,
-                                     stderr=subprocess.STDOUT,
-                                     bufsize=0)
-
-                # check if tabix exited early, look for tabix error
-                time.sleep(.5)
-                poll = p.poll()
-                if poll is not None and poll > 0:
-                    err = p.stdout.read()
-                    if not PY2:
-                        err = str(err, 'ascii')
-                    p.stdout.close()
-                    raise RuntimeError(err.strip())
-                fileobj = p.stdout
-                close = True
-                # N.B., still pass the region parameter through so we get strictly only
-                # variants that start within the requested region. See also
-                # https://github.com/alimanfoo/vcfnp/issues/54
-
-            except FileNotFoundError:
-                # no tabix, fall back to scanning
-                warnings.warn('tabix not found, falling back to scanning to region')
-                fileobj = gzip.open(input, mode='rb')
-                close = True
-
-            except Exception as e:
-                warnings.warn('error occurred attempting tabix (%s); falling back to '
-                              'scanning to region' % e)
-                fileobj = gzip.open(input, mode='rb')
-                close = True
-
-        else:
-            fileobj = gzip.open(input, mode='rb')
-            close = True
-
-    elif isinstance(input, str):
-        # assume no compression
-        fileobj = open(input, mode='rb', buffering=0)
-        close = True
-
-    elif hasattr(input, 'readinto'):
-        fileobj = input
-
-    else:
-        raise ValueError('path must be string or file-like, found %r' % input)
+                fills=fills, samples=samples, region=region)
 
     # setup input stream
-    stream = FileInputStream(fileobj, buffer_size=buffer_size, close=close)
-
-    # deal with region
-    kwds['region'] = region
+    stream = _setup_input_stream(input=input, region=region, tabix=tabix,
+                                 buffer_size=buffer_size)
 
     # setup iterator
     fields, samples, headers, it = _iter_vcf_stream(stream, **kwds)
@@ -1254,7 +1274,8 @@ def _normalize_fields(fields, headers, samples):
         elif f in ['calldata', 'calldata*', 'calldata/*'] and len(samples) > 0:
             _add_all_calldata_fields(normed_fields, headers)
 
-        elif f in ['INFO', 'INFO*', 'INFO/*', 'variants/INFO', 'variants/INFO*', 'variants/INFO/*']:
+        elif f in ['INFO', 'INFO*', 'INFO/*', 'variants/INFO', 'variants/INFO*',
+                   'variants/INFO/*']:
             _add_all_info_fields(normed_fields, headers)
 
         elif f in ['FILTER', 'FILTER*', 'FILTER/*', 'FILTER_*', 'variants/FILTER',
@@ -1361,7 +1382,8 @@ def _normalize_types(types, fields, headers):
                 header_type = _normalize_type(headers.infos[name]['Type'])
                 if isinstance(default_type, np.dtype):
                     # check that default is compatible with header
-                    if default_type.kind in 'ifb' and default_type.kind != header_type.kind:
+                    if (default_type.kind in 'ifb' and
+                            default_type.kind != header_type.kind):
                         # default is not compatible with header, fall back to header
                         t = header_type
                     else:
@@ -1386,7 +1408,8 @@ def _normalize_types(types, fields, headers):
                 header_type = _normalize_type(headers.formats[name]['Type'])
                 if isinstance(default_type, np.dtype):
                     # check that default is compatible with header
-                    if default_type.kind in 'ifb' and default_type.kind != header_type.kind:
+                    if (default_type.kind in 'ifb' and
+                            default_type.kind != header_type.kind):
                         # default is not compatible with header, fall back to header
                         t = header_type
                     else:
@@ -1481,7 +1504,8 @@ def _normalize_numbers(numbers, fields, headers, alt_number):
                 normed_numbers[f] = 0
 
             elif name in headers.infos:
-                normed_numbers[f] = _normalize_number(f, headers.infos[name]['Number'], alt_number)
+                normed_numbers[f] = _normalize_number(f, headers.infos[name]['Number'],
+                                                      alt_number)
 
             else:
                 # fall back to 1
@@ -1561,7 +1585,8 @@ def _iter_vcf_stream(stream, fields, exclude_fields, types, numbers, alt_number,
     headers = _read_vcf_headers(stream)
 
     # setup samples
-    samples, loc_samples = _normalize_samples(samples=samples, headers=headers, types=types)
+    samples, loc_samples = _normalize_samples(samples=samples, headers=headers,
+                                              types=types)
 
     # setup fields to read
     if fields is None:
@@ -1610,7 +1635,15 @@ _re_format_header = \
     re.compile('##FORMAT=<ID=([^,]+),Number=([^,]+),Type=([^,]+),Description="([^"]*)">')
 
 
-VCFHeaders = namedtuple('VCFHeaders', ['headers', 'filters', 'infos', 'formats', 'samples'])
+VCFHeaders = namedtuple('VCFHeaders', ['headers', 'filters', 'infos', 'formats',
+                                       'samples'])
+
+
+# noinspection PyShadowingBuiltins
+def read_vcf_headers(input):
+    """Read headers from a VCF file."""
+    stream = _setup_input_stream(input)
+    return _read_vcf_headers(stream)
 
 
 def _read_vcf_headers(stream):
@@ -1704,6 +1737,7 @@ def _chunk_to_dataframe(fields, chunk):
     return df
 
 
+# noinspection PyShadowingBuiltins
 def vcf_to_dataframe(input,
                      fields=None,
                      exclude_fields=None,
@@ -1804,6 +1838,7 @@ vcf_to_dataframe.__doc__ = vcf_to_dataframe.__doc__.format(
 )
 
 
+# noinspection PyShadowingBuiltins
 def vcf_to_csv(input, output,
                fields=None,
                exclude_fields=None,
@@ -1921,6 +1956,7 @@ def _chunk_to_recarray(fields, chunk):
     return ra
 
 
+# noinspection PyShadowingBuiltins
 def vcf_to_recarray(input,
                     fields=None,
                     exclude_fields=None,

--- a/allel/io/vcf_read.py
+++ b/allel/io/vcf_read.py
@@ -140,78 +140,78 @@ _doc_param_input = \
 
 _doc_param_fields = \
     """Fields to extract data for. Should be a list of strings, e.g., ``['variants/CHROM',
-        'variants/POS', 'variants/DP', 'calldata/GT']``. If you are feeling lazy, 
-        you can drop the 'variants/' and 'calldata/' prefixes, in which case the fields 
-        will be matched against fields declared in the VCF header, with variants taking 
-        priority over calldata if a field with the same ID exists both in INFO and 
-        FORMAT headers. I.e., ``['CHROM', 'POS', 'DP', 'GT']`` will work, although 
-        watch out for fields like 'DP' which can be both INFO and FORMAT. For 
-        convenience, some special string values are also recognized. To extract all 
-        fields, provide just the string ``'*'``. To extract all variants fields 
-        (including all INFO fields) provide ``'variants/*'``. To extract all calldata 
+        'variants/POS', 'variants/DP', 'calldata/GT']``. If you are feeling lazy,
+        you can drop the 'variants/' and 'calldata/' prefixes, in which case the fields
+        will be matched against fields declared in the VCF header, with variants taking
+        priority over calldata if a field with the same ID exists both in INFO and
+        FORMAT headers. I.e., ``['CHROM', 'POS', 'DP', 'GT']`` will work, although
+        watch out for fields like 'DP' which can be both INFO and FORMAT. For
+        convenience, some special string values are also recognized. To extract all
+        fields, provide just the string ``'*'``. To extract all variants fields
+        (including all INFO fields) provide ``'variants/*'``. To extract all calldata
         fields (i.e., defined in FORMAT headers) provide ``'calldata/*'``."""
 
 _doc_param_exclude_fields = \
     """Fields to exclude. E.g., for use in combination with ``fields='*'``."""
 
 _doc_param_rename_fields = \
-    """Fields to be renamed. Should be a dictionary mapping old to new names, 
+    """Fields to be renamed. Should be a dictionary mapping old to new names,
     giving the complete path, e.g., ``{'variants/FOO': 'variants/bar'}``."""
 
 _doc_param_types = \
     """Overide data types. Should be a dictionary mapping field names to NumPy data types.
-        E.g., providing the dictionary ``{'variants/DP': 'i8', 'calldata/GQ': 'i2'}`` will 
-        mean the 'variants/DP' field is stored in a 64-bit integer array, and the 
+        E.g., providing the dictionary ``{'variants/DP': 'i8', 'calldata/GQ': 'i2'}`` will
+        mean the 'variants/DP' field is stored in a 64-bit integer array, and the
         'calldata/GQ' field is stored in a 16-bit integer array."""
 
 _doc_param_numbers = \
-    """Override the expected number of values. Should be a dictionary mapping field names 
-        to integers. E.g., providing the dictionary ``{'variants/ALT': 5, 
-        'variants/AC': 5, 'calldata/HQ': 2}`` will mean that, for each variant, 5 values 
-        are stored for the 'variants/ALT' field, 5 values are stored for the 
-        'variants/AC' field, and for each sample, 2 values are stored for the 
+    """Override the expected number of values. Should be a dictionary mapping field names
+        to integers. E.g., providing the dictionary ``{'variants/ALT': 5,
+        'variants/AC': 5, 'calldata/HQ': 2}`` will mean that, for each variant, 5 values
+        are stored for the 'variants/ALT' field, 5 values are stored for the
+        'variants/AC' field, and for each sample, 2 values are stored for the
         'calldata/HQ' field."""
 
 _doc_param_alt_number = \
-    """Assume this number of alternate alleles and set expected number of values 
-        accordingly for any field declared with number 'A' or 'R' in the VCF 
+    """Assume this number of alternate alleles and set expected number of values
+        accordingly for any field declared with number 'A' or 'R' in the VCF
         meta-information."""
 
 _doc_param_fills = \
-    """Override the fill value used for empty values. Should be a dictionary mapping 
+    """Override the fill value used for empty values. Should be a dictionary mapping
         field names to fill values."""
 
 _doc_param_region = \
-    """Genomic region to extract variants for. If provided, should be a tabix-style 
-        region string, which can be either just a chromosome name (e.g., '2L'), 
-        or a chromosome name followed by 1-based beginning and end coordinates (e.g., 
-        '2L:100000-200000'). Note that only variants whose start position (POS) is 
-        within the requested range will be included. This is slightly different from 
-        the default tabix behaviour, where a variant (e.g., deletion) may be included 
-        if its position (POS) occurs before the requested region but its reference allele 
-        overlaps the region - such a variant will *not* be included in the data 
+    """Genomic region to extract variants for. If provided, should be a tabix-style
+        region string, which can be either just a chromosome name (e.g., '2L'),
+        or a chromosome name followed by 1-based beginning and end coordinates (e.g.,
+        '2L:100000-200000'). Note that only variants whose start position (POS) is
+        within the requested range will be included. This is slightly different from
+        the default tabix behaviour, where a variant (e.g., deletion) may be included
+        if its position (POS) occurs before the requested region but its reference allele
+        overlaps the region - such a variant will *not* be included in the data
         returned by this function."""
 
 _doc_param_tabix = \
-    """Name or path to tabix executable. Only required if `region` is given. Setting 
-        `tabix` to `None` will cause a fall-back to scanning through the VCF file from 
-        the beginning, which may be much slower than tabix but the only option if tabix 
+    """Name or path to tabix executable. Only required if `region` is given. Setting
+        `tabix` to `None` will cause a fall-back to scanning through the VCF file from
+        the beginning, which may be much slower than tabix but the only option if tabix
         is not available on your system and/or the VCF file has not been tabix-indexed."""
 
 _doc_param_samples = \
-    """Selection of samples to extract calldata for. If provided, should be a list of 
-        strings giving sample identifiers. May also be a list of integers giving 
+    """Selection of samples to extract calldata for. If provided, should be a list of
+        strings giving sample identifiers. May also be a list of integers giving
         indices of selected samples."""
 
 _doc_param_transformers = \
     """Transformers for post-processing data. If provided, should be a list of Transformer
         objects, each of which must implement a "transform()" method that accepts a dict
-        containing the chunk of data to be transformed. See also the 
-        :class:`ANNTransformer` class which implements post-processing of data from 
+        containing the chunk of data to be transformed. See also the
+        :class:`ANNTransformer` class which implements post-processing of data from
         SNPEFF."""
 
 _doc_param_buffer_size = \
-    """Size in bytes of the I/O buffer used when reading data from the underlying file or 
+    """Size in bytes of the I/O buffer used when reading data from the underlying file or
         tabix stream."""
 
 _doc_param_chunk_length = \

--- a/allel/io/vcf_read.py
+++ b/allel/io/vcf_read.py
@@ -37,6 +37,13 @@ DEFAULT_CHUNK_WIDTH = 2**6
 DEFAULT_ALT_NUMBER = 3
 
 
+# names for computed fields
+FIELD_NUMALT = 'numalt'
+FIELD_ALTLEN = 'altlen'
+FIELD_IS_SNP = 'is_snp'
+COMPUTED_FIELDS = [FIELD_NUMALT, FIELD_ALTLEN, FIELD_IS_SNP]
+
+
 def _prep_fields_param(fields):
     """Prepare the `fields` parameter, and determine whether or not to store samples."""
 
@@ -1029,7 +1036,7 @@ def _check_field(field, headers):
         if name in FIXED_VARIANTS_FIELDS:
             pass
 
-        elif name in ['numalt', 'svlen', 'is_snp']:
+        elif name in COMPUTED_FIELDS:
             # computed fields
             pass
 
@@ -1069,10 +1076,7 @@ def _add_all_variants_fields(fields, headers):
     _add_all_fixed_variants_fields(fields)
     _add_all_info_fields(fields, headers)
     _add_all_filter_fields(fields, headers)
-    # add in computed fields
-    for f in 'variants/numalt', 'variants/svlen', 'variants/is_snp':
-        if f not in fields:
-            fields.append(f)
+    _add_all_computed_fields(fields)
 
 
 def _add_all_fixed_variants_fields(fields):
@@ -1093,6 +1097,13 @@ def _add_all_filter_fields(fields, headers):
     fields.append('variants/FILTER_PASS')
     for k in headers.filters:
         f = 'variants/FILTER_' + k
+        if f not in fields:
+            fields.append(f)
+
+
+def _add_all_computed_fields(fields):
+    for k in COMPUTED_FIELDS:
+        f = 'variants/' + k
         if f not in fields:
             fields.append(f)
 
@@ -1224,7 +1235,7 @@ def _normalize_types(types, fields, headers):
 
         elif group == 'variants':
 
-            if name in ['numalt', 'svlen', 'is_snp']:
+            if name in COMPUTED_FIELDS:
                 # computed fields, special case
                 continue
 
@@ -1347,8 +1358,8 @@ def _normalize_numbers(numbers, fields, headers, alt_number):
 
         elif group == 'variants':
 
-            if name in ['numalt', 'svlen', 'is_snp']:
-                # computed fields, special case (for svlen, number depends on ALT)
+            if name in COMPUTED_FIELDS:
+                # computed fields, special case (for altlen, number depends on ALT)
                 continue
 
             elif name.startswith('FILTER_'):

--- a/allel/io/vcf_read.py
+++ b/allel/io/vcf_read.py
@@ -10,11 +10,10 @@ from __future__ import absolute_import, print_function, division
 import gzip
 import os
 import re
-from collections import namedtuple
+from collections import namedtuple, defaultdict
 import warnings
 import time
 import subprocess
-from collections import defaultdict
 import textwrap
 
 

--- a/allel/opt/model.c
+++ b/allel/opt/model.c
@@ -855,9 +855,9 @@ static const char *__pyx_filename;
 
 static const char *__pyx_f[] = {
   "allel/opt/model.pyx",
-  ".tox/py37/lib/python3.7/site-packages/Cython/Includes/numpy/__init__.pxd",
+  "__init__.pxd",
   "stringsource",
-  ".tox/py37/lib/python3.7/site-packages/Cython/Includes/cpython/type.pxd",
+  "type.pxd",
 };
 /* NoFastGil.proto */
 #define __Pyx_PyGILState_Ensure PyGILState_Ensure
@@ -968,7 +968,7 @@ typedef struct {
 } __Pyx_BufFmt_Context;
 
 
-/* ".tox/py37/lib/python3.7/site-packages/Cython/Includes/numpy/__init__.pxd":776
+/* "../../../pyenv/scikit-allel-py37/lib/python3.7/site-packages/Cython/Includes/numpy/__init__.pxd":776
  * # in Cython to enable them only on the right systems.
  * 
  * ctypedef npy_int8       int8_t             # <<<<<<<<<<<<<<
@@ -977,7 +977,7 @@ typedef struct {
  */
 typedef npy_int8 __pyx_t_5numpy_int8_t;
 
-/* ".tox/py37/lib/python3.7/site-packages/Cython/Includes/numpy/__init__.pxd":777
+/* "../../../pyenv/scikit-allel-py37/lib/python3.7/site-packages/Cython/Includes/numpy/__init__.pxd":777
  * 
  * ctypedef npy_int8       int8_t
  * ctypedef npy_int16      int16_t             # <<<<<<<<<<<<<<
@@ -986,7 +986,7 @@ typedef npy_int8 __pyx_t_5numpy_int8_t;
  */
 typedef npy_int16 __pyx_t_5numpy_int16_t;
 
-/* ".tox/py37/lib/python3.7/site-packages/Cython/Includes/numpy/__init__.pxd":778
+/* "../../../pyenv/scikit-allel-py37/lib/python3.7/site-packages/Cython/Includes/numpy/__init__.pxd":778
  * ctypedef npy_int8       int8_t
  * ctypedef npy_int16      int16_t
  * ctypedef npy_int32      int32_t             # <<<<<<<<<<<<<<
@@ -995,7 +995,7 @@ typedef npy_int16 __pyx_t_5numpy_int16_t;
  */
 typedef npy_int32 __pyx_t_5numpy_int32_t;
 
-/* ".tox/py37/lib/python3.7/site-packages/Cython/Includes/numpy/__init__.pxd":779
+/* "../../../pyenv/scikit-allel-py37/lib/python3.7/site-packages/Cython/Includes/numpy/__init__.pxd":779
  * ctypedef npy_int16      int16_t
  * ctypedef npy_int32      int32_t
  * ctypedef npy_int64      int64_t             # <<<<<<<<<<<<<<
@@ -1004,7 +1004,7 @@ typedef npy_int32 __pyx_t_5numpy_int32_t;
  */
 typedef npy_int64 __pyx_t_5numpy_int64_t;
 
-/* ".tox/py37/lib/python3.7/site-packages/Cython/Includes/numpy/__init__.pxd":783
+/* "../../../pyenv/scikit-allel-py37/lib/python3.7/site-packages/Cython/Includes/numpy/__init__.pxd":783
  * #ctypedef npy_int128     int128_t
  * 
  * ctypedef npy_uint8      uint8_t             # <<<<<<<<<<<<<<
@@ -1013,7 +1013,7 @@ typedef npy_int64 __pyx_t_5numpy_int64_t;
  */
 typedef npy_uint8 __pyx_t_5numpy_uint8_t;
 
-/* ".tox/py37/lib/python3.7/site-packages/Cython/Includes/numpy/__init__.pxd":784
+/* "../../../pyenv/scikit-allel-py37/lib/python3.7/site-packages/Cython/Includes/numpy/__init__.pxd":784
  * 
  * ctypedef npy_uint8      uint8_t
  * ctypedef npy_uint16     uint16_t             # <<<<<<<<<<<<<<
@@ -1022,7 +1022,7 @@ typedef npy_uint8 __pyx_t_5numpy_uint8_t;
  */
 typedef npy_uint16 __pyx_t_5numpy_uint16_t;
 
-/* ".tox/py37/lib/python3.7/site-packages/Cython/Includes/numpy/__init__.pxd":785
+/* "../../../pyenv/scikit-allel-py37/lib/python3.7/site-packages/Cython/Includes/numpy/__init__.pxd":785
  * ctypedef npy_uint8      uint8_t
  * ctypedef npy_uint16     uint16_t
  * ctypedef npy_uint32     uint32_t             # <<<<<<<<<<<<<<
@@ -1031,7 +1031,7 @@ typedef npy_uint16 __pyx_t_5numpy_uint16_t;
  */
 typedef npy_uint32 __pyx_t_5numpy_uint32_t;
 
-/* ".tox/py37/lib/python3.7/site-packages/Cython/Includes/numpy/__init__.pxd":786
+/* "../../../pyenv/scikit-allel-py37/lib/python3.7/site-packages/Cython/Includes/numpy/__init__.pxd":786
  * ctypedef npy_uint16     uint16_t
  * ctypedef npy_uint32     uint32_t
  * ctypedef npy_uint64     uint64_t             # <<<<<<<<<<<<<<
@@ -1040,7 +1040,7 @@ typedef npy_uint32 __pyx_t_5numpy_uint32_t;
  */
 typedef npy_uint64 __pyx_t_5numpy_uint64_t;
 
-/* ".tox/py37/lib/python3.7/site-packages/Cython/Includes/numpy/__init__.pxd":790
+/* "../../../pyenv/scikit-allel-py37/lib/python3.7/site-packages/Cython/Includes/numpy/__init__.pxd":790
  * #ctypedef npy_uint128    uint128_t
  * 
  * ctypedef npy_float32    float32_t             # <<<<<<<<<<<<<<
@@ -1049,7 +1049,7 @@ typedef npy_uint64 __pyx_t_5numpy_uint64_t;
  */
 typedef npy_float32 __pyx_t_5numpy_float32_t;
 
-/* ".tox/py37/lib/python3.7/site-packages/Cython/Includes/numpy/__init__.pxd":791
+/* "../../../pyenv/scikit-allel-py37/lib/python3.7/site-packages/Cython/Includes/numpy/__init__.pxd":791
  * 
  * ctypedef npy_float32    float32_t
  * ctypedef npy_float64    float64_t             # <<<<<<<<<<<<<<
@@ -1058,7 +1058,7 @@ typedef npy_float32 __pyx_t_5numpy_float32_t;
  */
 typedef npy_float64 __pyx_t_5numpy_float64_t;
 
-/* ".tox/py37/lib/python3.7/site-packages/Cython/Includes/numpy/__init__.pxd":800
+/* "../../../pyenv/scikit-allel-py37/lib/python3.7/site-packages/Cython/Includes/numpy/__init__.pxd":800
  * # The int types are mapped a bit surprising --
  * # numpy.int corresponds to 'l' and numpy.long to 'q'
  * ctypedef npy_long       int_t             # <<<<<<<<<<<<<<
@@ -1067,7 +1067,7 @@ typedef npy_float64 __pyx_t_5numpy_float64_t;
  */
 typedef npy_long __pyx_t_5numpy_int_t;
 
-/* ".tox/py37/lib/python3.7/site-packages/Cython/Includes/numpy/__init__.pxd":801
+/* "../../../pyenv/scikit-allel-py37/lib/python3.7/site-packages/Cython/Includes/numpy/__init__.pxd":801
  * # numpy.int corresponds to 'l' and numpy.long to 'q'
  * ctypedef npy_long       int_t
  * ctypedef npy_longlong   long_t             # <<<<<<<<<<<<<<
@@ -1076,7 +1076,7 @@ typedef npy_long __pyx_t_5numpy_int_t;
  */
 typedef npy_longlong __pyx_t_5numpy_long_t;
 
-/* ".tox/py37/lib/python3.7/site-packages/Cython/Includes/numpy/__init__.pxd":802
+/* "../../../pyenv/scikit-allel-py37/lib/python3.7/site-packages/Cython/Includes/numpy/__init__.pxd":802
  * ctypedef npy_long       int_t
  * ctypedef npy_longlong   long_t
  * ctypedef npy_longlong   longlong_t             # <<<<<<<<<<<<<<
@@ -1085,7 +1085,7 @@ typedef npy_longlong __pyx_t_5numpy_long_t;
  */
 typedef npy_longlong __pyx_t_5numpy_longlong_t;
 
-/* ".tox/py37/lib/python3.7/site-packages/Cython/Includes/numpy/__init__.pxd":804
+/* "../../../pyenv/scikit-allel-py37/lib/python3.7/site-packages/Cython/Includes/numpy/__init__.pxd":804
  * ctypedef npy_longlong   longlong_t
  * 
  * ctypedef npy_ulong      uint_t             # <<<<<<<<<<<<<<
@@ -1094,7 +1094,7 @@ typedef npy_longlong __pyx_t_5numpy_longlong_t;
  */
 typedef npy_ulong __pyx_t_5numpy_uint_t;
 
-/* ".tox/py37/lib/python3.7/site-packages/Cython/Includes/numpy/__init__.pxd":805
+/* "../../../pyenv/scikit-allel-py37/lib/python3.7/site-packages/Cython/Includes/numpy/__init__.pxd":805
  * 
  * ctypedef npy_ulong      uint_t
  * ctypedef npy_ulonglong  ulong_t             # <<<<<<<<<<<<<<
@@ -1103,7 +1103,7 @@ typedef npy_ulong __pyx_t_5numpy_uint_t;
  */
 typedef npy_ulonglong __pyx_t_5numpy_ulong_t;
 
-/* ".tox/py37/lib/python3.7/site-packages/Cython/Includes/numpy/__init__.pxd":806
+/* "../../../pyenv/scikit-allel-py37/lib/python3.7/site-packages/Cython/Includes/numpy/__init__.pxd":806
  * ctypedef npy_ulong      uint_t
  * ctypedef npy_ulonglong  ulong_t
  * ctypedef npy_ulonglong  ulonglong_t             # <<<<<<<<<<<<<<
@@ -1112,7 +1112,7 @@ typedef npy_ulonglong __pyx_t_5numpy_ulong_t;
  */
 typedef npy_ulonglong __pyx_t_5numpy_ulonglong_t;
 
-/* ".tox/py37/lib/python3.7/site-packages/Cython/Includes/numpy/__init__.pxd":808
+/* "../../../pyenv/scikit-allel-py37/lib/python3.7/site-packages/Cython/Includes/numpy/__init__.pxd":808
  * ctypedef npy_ulonglong  ulonglong_t
  * 
  * ctypedef npy_intp       intp_t             # <<<<<<<<<<<<<<
@@ -1121,7 +1121,7 @@ typedef npy_ulonglong __pyx_t_5numpy_ulonglong_t;
  */
 typedef npy_intp __pyx_t_5numpy_intp_t;
 
-/* ".tox/py37/lib/python3.7/site-packages/Cython/Includes/numpy/__init__.pxd":809
+/* "../../../pyenv/scikit-allel-py37/lib/python3.7/site-packages/Cython/Includes/numpy/__init__.pxd":809
  * 
  * ctypedef npy_intp       intp_t
  * ctypedef npy_uintp      uintp_t             # <<<<<<<<<<<<<<
@@ -1130,7 +1130,7 @@ typedef npy_intp __pyx_t_5numpy_intp_t;
  */
 typedef npy_uintp __pyx_t_5numpy_uintp_t;
 
-/* ".tox/py37/lib/python3.7/site-packages/Cython/Includes/numpy/__init__.pxd":811
+/* "../../../pyenv/scikit-allel-py37/lib/python3.7/site-packages/Cython/Includes/numpy/__init__.pxd":811
  * ctypedef npy_uintp      uintp_t
  * 
  * ctypedef npy_double     float_t             # <<<<<<<<<<<<<<
@@ -1139,7 +1139,7 @@ typedef npy_uintp __pyx_t_5numpy_uintp_t;
  */
 typedef npy_double __pyx_t_5numpy_float_t;
 
-/* ".tox/py37/lib/python3.7/site-packages/Cython/Includes/numpy/__init__.pxd":812
+/* "../../../pyenv/scikit-allel-py37/lib/python3.7/site-packages/Cython/Includes/numpy/__init__.pxd":812
  * 
  * ctypedef npy_double     float_t
  * ctypedef npy_double     double_t             # <<<<<<<<<<<<<<
@@ -1148,7 +1148,7 @@ typedef npy_double __pyx_t_5numpy_float_t;
  */
 typedef npy_double __pyx_t_5numpy_double_t;
 
-/* ".tox/py37/lib/python3.7/site-packages/Cython/Includes/numpy/__init__.pxd":813
+/* "../../../pyenv/scikit-allel-py37/lib/python3.7/site-packages/Cython/Includes/numpy/__init__.pxd":813
  * ctypedef npy_double     float_t
  * ctypedef npy_double     double_t
  * ctypedef npy_longdouble longdouble_t             # <<<<<<<<<<<<<<
@@ -1187,7 +1187,7 @@ struct __pyx_MemviewEnum_obj;
 struct __pyx_memoryview_obj;
 struct __pyx_memoryviewslice_obj;
 
-/* ".tox/py37/lib/python3.7/site-packages/Cython/Includes/numpy/__init__.pxd":815
+/* "../../../pyenv/scikit-allel-py37/lib/python3.7/site-packages/Cython/Includes/numpy/__init__.pxd":815
  * ctypedef npy_longdouble longdouble_t
  * 
  * ctypedef npy_cfloat      cfloat_t             # <<<<<<<<<<<<<<
@@ -1196,7 +1196,7 @@ struct __pyx_memoryviewslice_obj;
  */
 typedef npy_cfloat __pyx_t_5numpy_cfloat_t;
 
-/* ".tox/py37/lib/python3.7/site-packages/Cython/Includes/numpy/__init__.pxd":816
+/* "../../../pyenv/scikit-allel-py37/lib/python3.7/site-packages/Cython/Includes/numpy/__init__.pxd":816
  * 
  * ctypedef npy_cfloat      cfloat_t
  * ctypedef npy_cdouble     cdouble_t             # <<<<<<<<<<<<<<
@@ -1205,7 +1205,7 @@ typedef npy_cfloat __pyx_t_5numpy_cfloat_t;
  */
 typedef npy_cdouble __pyx_t_5numpy_cdouble_t;
 
-/* ".tox/py37/lib/python3.7/site-packages/Cython/Includes/numpy/__init__.pxd":817
+/* "../../../pyenv/scikit-allel-py37/lib/python3.7/site-packages/Cython/Includes/numpy/__init__.pxd":817
  * ctypedef npy_cfloat      cfloat_t
  * ctypedef npy_cdouble     cdouble_t
  * ctypedef npy_clongdouble clongdouble_t             # <<<<<<<<<<<<<<
@@ -1214,7 +1214,7 @@ typedef npy_cdouble __pyx_t_5numpy_cdouble_t;
  */
 typedef npy_clongdouble __pyx_t_5numpy_clongdouble_t;
 
-/* ".tox/py37/lib/python3.7/site-packages/Cython/Includes/numpy/__init__.pxd":819
+/* "../../../pyenv/scikit-allel-py37/lib/python3.7/site-packages/Cython/Includes/numpy/__init__.pxd":819
  * ctypedef npy_clongdouble clongdouble_t
  * 
  * ctypedef npy_cdouble     complex_t             # <<<<<<<<<<<<<<
@@ -33804,7 +33804,7 @@ static PyObject *__pyx_pf_5allel_3opt_5model_158haplotype_array_map_alleles(CYTH
   return __pyx_r;
 }
 
-/* ".tox/py37/lib/python3.7/site-packages/Cython/Includes/numpy/__init__.pxd":258
+/* "../../../pyenv/scikit-allel-py37/lib/python3.7/site-packages/Cython/Includes/numpy/__init__.pxd":258
  *         # experimental exception made for __getbuffer__ and __releasebuffer__
  *         # -- the details of this may change.
  *         def __getbuffer__(ndarray self, Py_buffer* info, int flags):             # <<<<<<<<<<<<<<
@@ -33853,7 +33853,7 @@ static int __pyx_pf_5numpy_7ndarray___getbuffer__(PyArrayObject *__pyx_v_self, P
   __pyx_v_info->obj = Py_None; __Pyx_INCREF(Py_None);
   __Pyx_GIVEREF(__pyx_v_info->obj);
 
-  /* ".tox/py37/lib/python3.7/site-packages/Cython/Includes/numpy/__init__.pxd":265
+  /* "../../../pyenv/scikit-allel-py37/lib/python3.7/site-packages/Cython/Includes/numpy/__init__.pxd":265
  * 
  *             cdef int i, ndim
  *             cdef int endian_detector = 1             # <<<<<<<<<<<<<<
@@ -33862,7 +33862,7 @@ static int __pyx_pf_5numpy_7ndarray___getbuffer__(PyArrayObject *__pyx_v_self, P
  */
   __pyx_v_endian_detector = 1;
 
-  /* ".tox/py37/lib/python3.7/site-packages/Cython/Includes/numpy/__init__.pxd":266
+  /* "../../../pyenv/scikit-allel-py37/lib/python3.7/site-packages/Cython/Includes/numpy/__init__.pxd":266
  *             cdef int i, ndim
  *             cdef int endian_detector = 1
  *             cdef bint little_endian = ((<char*>&endian_detector)[0] != 0)             # <<<<<<<<<<<<<<
@@ -33871,7 +33871,7 @@ static int __pyx_pf_5numpy_7ndarray___getbuffer__(PyArrayObject *__pyx_v_self, P
  */
   __pyx_v_little_endian = ((((char *)(&__pyx_v_endian_detector))[0]) != 0);
 
-  /* ".tox/py37/lib/python3.7/site-packages/Cython/Includes/numpy/__init__.pxd":268
+  /* "../../../pyenv/scikit-allel-py37/lib/python3.7/site-packages/Cython/Includes/numpy/__init__.pxd":268
  *             cdef bint little_endian = ((<char*>&endian_detector)[0] != 0)
  * 
  *             ndim = PyArray_NDIM(self)             # <<<<<<<<<<<<<<
@@ -33880,7 +33880,7 @@ static int __pyx_pf_5numpy_7ndarray___getbuffer__(PyArrayObject *__pyx_v_self, P
  */
   __pyx_v_ndim = PyArray_NDIM(__pyx_v_self);
 
-  /* ".tox/py37/lib/python3.7/site-packages/Cython/Includes/numpy/__init__.pxd":270
+  /* "../../../pyenv/scikit-allel-py37/lib/python3.7/site-packages/Cython/Includes/numpy/__init__.pxd":270
  *             ndim = PyArray_NDIM(self)
  * 
  *             if ((flags & pybuf.PyBUF_C_CONTIGUOUS == pybuf.PyBUF_C_CONTIGUOUS)             # <<<<<<<<<<<<<<
@@ -33894,7 +33894,7 @@ static int __pyx_pf_5numpy_7ndarray___getbuffer__(PyArrayObject *__pyx_v_self, P
     goto __pyx_L4_bool_binop_done;
   }
 
-  /* ".tox/py37/lib/python3.7/site-packages/Cython/Includes/numpy/__init__.pxd":271
+  /* "../../../pyenv/scikit-allel-py37/lib/python3.7/site-packages/Cython/Includes/numpy/__init__.pxd":271
  * 
  *             if ((flags & pybuf.PyBUF_C_CONTIGUOUS == pybuf.PyBUF_C_CONTIGUOUS)
  *                 and not PyArray_CHKFLAGS(self, NPY_ARRAY_C_CONTIGUOUS)):             # <<<<<<<<<<<<<<
@@ -33905,7 +33905,7 @@ static int __pyx_pf_5numpy_7ndarray___getbuffer__(PyArrayObject *__pyx_v_self, P
   __pyx_t_1 = __pyx_t_2;
   __pyx_L4_bool_binop_done:;
 
-  /* ".tox/py37/lib/python3.7/site-packages/Cython/Includes/numpy/__init__.pxd":270
+  /* "../../../pyenv/scikit-allel-py37/lib/python3.7/site-packages/Cython/Includes/numpy/__init__.pxd":270
  *             ndim = PyArray_NDIM(self)
  * 
  *             if ((flags & pybuf.PyBUF_C_CONTIGUOUS == pybuf.PyBUF_C_CONTIGUOUS)             # <<<<<<<<<<<<<<
@@ -33914,7 +33914,7 @@ static int __pyx_pf_5numpy_7ndarray___getbuffer__(PyArrayObject *__pyx_v_self, P
  */
   if (unlikely(__pyx_t_1)) {
 
-    /* ".tox/py37/lib/python3.7/site-packages/Cython/Includes/numpy/__init__.pxd":272
+    /* "../../../pyenv/scikit-allel-py37/lib/python3.7/site-packages/Cython/Includes/numpy/__init__.pxd":272
  *             if ((flags & pybuf.PyBUF_C_CONTIGUOUS == pybuf.PyBUF_C_CONTIGUOUS)
  *                 and not PyArray_CHKFLAGS(self, NPY_ARRAY_C_CONTIGUOUS)):
  *                 raise ValueError(u"ndarray is not C contiguous")             # <<<<<<<<<<<<<<
@@ -33927,7 +33927,7 @@ static int __pyx_pf_5numpy_7ndarray___getbuffer__(PyArrayObject *__pyx_v_self, P
     __Pyx_DECREF(__pyx_t_3); __pyx_t_3 = 0;
     __PYX_ERR(1, 272, __pyx_L1_error)
 
-    /* ".tox/py37/lib/python3.7/site-packages/Cython/Includes/numpy/__init__.pxd":270
+    /* "../../../pyenv/scikit-allel-py37/lib/python3.7/site-packages/Cython/Includes/numpy/__init__.pxd":270
  *             ndim = PyArray_NDIM(self)
  * 
  *             if ((flags & pybuf.PyBUF_C_CONTIGUOUS == pybuf.PyBUF_C_CONTIGUOUS)             # <<<<<<<<<<<<<<
@@ -33936,7 +33936,7 @@ static int __pyx_pf_5numpy_7ndarray___getbuffer__(PyArrayObject *__pyx_v_self, P
  */
   }
 
-  /* ".tox/py37/lib/python3.7/site-packages/Cython/Includes/numpy/__init__.pxd":274
+  /* "../../../pyenv/scikit-allel-py37/lib/python3.7/site-packages/Cython/Includes/numpy/__init__.pxd":274
  *                 raise ValueError(u"ndarray is not C contiguous")
  * 
  *             if ((flags & pybuf.PyBUF_F_CONTIGUOUS == pybuf.PyBUF_F_CONTIGUOUS)             # <<<<<<<<<<<<<<
@@ -33950,7 +33950,7 @@ static int __pyx_pf_5numpy_7ndarray___getbuffer__(PyArrayObject *__pyx_v_self, P
     goto __pyx_L7_bool_binop_done;
   }
 
-  /* ".tox/py37/lib/python3.7/site-packages/Cython/Includes/numpy/__init__.pxd":275
+  /* "../../../pyenv/scikit-allel-py37/lib/python3.7/site-packages/Cython/Includes/numpy/__init__.pxd":275
  * 
  *             if ((flags & pybuf.PyBUF_F_CONTIGUOUS == pybuf.PyBUF_F_CONTIGUOUS)
  *                 and not PyArray_CHKFLAGS(self, NPY_ARRAY_F_CONTIGUOUS)):             # <<<<<<<<<<<<<<
@@ -33961,7 +33961,7 @@ static int __pyx_pf_5numpy_7ndarray___getbuffer__(PyArrayObject *__pyx_v_self, P
   __pyx_t_1 = __pyx_t_2;
   __pyx_L7_bool_binop_done:;
 
-  /* ".tox/py37/lib/python3.7/site-packages/Cython/Includes/numpy/__init__.pxd":274
+  /* "../../../pyenv/scikit-allel-py37/lib/python3.7/site-packages/Cython/Includes/numpy/__init__.pxd":274
  *                 raise ValueError(u"ndarray is not C contiguous")
  * 
  *             if ((flags & pybuf.PyBUF_F_CONTIGUOUS == pybuf.PyBUF_F_CONTIGUOUS)             # <<<<<<<<<<<<<<
@@ -33970,7 +33970,7 @@ static int __pyx_pf_5numpy_7ndarray___getbuffer__(PyArrayObject *__pyx_v_self, P
  */
   if (unlikely(__pyx_t_1)) {
 
-    /* ".tox/py37/lib/python3.7/site-packages/Cython/Includes/numpy/__init__.pxd":276
+    /* "../../../pyenv/scikit-allel-py37/lib/python3.7/site-packages/Cython/Includes/numpy/__init__.pxd":276
  *             if ((flags & pybuf.PyBUF_F_CONTIGUOUS == pybuf.PyBUF_F_CONTIGUOUS)
  *                 and not PyArray_CHKFLAGS(self, NPY_ARRAY_F_CONTIGUOUS)):
  *                 raise ValueError(u"ndarray is not Fortran contiguous")             # <<<<<<<<<<<<<<
@@ -33983,7 +33983,7 @@ static int __pyx_pf_5numpy_7ndarray___getbuffer__(PyArrayObject *__pyx_v_self, P
     __Pyx_DECREF(__pyx_t_3); __pyx_t_3 = 0;
     __PYX_ERR(1, 276, __pyx_L1_error)
 
-    /* ".tox/py37/lib/python3.7/site-packages/Cython/Includes/numpy/__init__.pxd":274
+    /* "../../../pyenv/scikit-allel-py37/lib/python3.7/site-packages/Cython/Includes/numpy/__init__.pxd":274
  *                 raise ValueError(u"ndarray is not C contiguous")
  * 
  *             if ((flags & pybuf.PyBUF_F_CONTIGUOUS == pybuf.PyBUF_F_CONTIGUOUS)             # <<<<<<<<<<<<<<
@@ -33992,7 +33992,7 @@ static int __pyx_pf_5numpy_7ndarray___getbuffer__(PyArrayObject *__pyx_v_self, P
  */
   }
 
-  /* ".tox/py37/lib/python3.7/site-packages/Cython/Includes/numpy/__init__.pxd":278
+  /* "../../../pyenv/scikit-allel-py37/lib/python3.7/site-packages/Cython/Includes/numpy/__init__.pxd":278
  *                 raise ValueError(u"ndarray is not Fortran contiguous")
  * 
  *             info.buf = PyArray_DATA(self)             # <<<<<<<<<<<<<<
@@ -34001,7 +34001,7 @@ static int __pyx_pf_5numpy_7ndarray___getbuffer__(PyArrayObject *__pyx_v_self, P
  */
   __pyx_v_info->buf = PyArray_DATA(__pyx_v_self);
 
-  /* ".tox/py37/lib/python3.7/site-packages/Cython/Includes/numpy/__init__.pxd":279
+  /* "../../../pyenv/scikit-allel-py37/lib/python3.7/site-packages/Cython/Includes/numpy/__init__.pxd":279
  * 
  *             info.buf = PyArray_DATA(self)
  *             info.ndim = ndim             # <<<<<<<<<<<<<<
@@ -34010,7 +34010,7 @@ static int __pyx_pf_5numpy_7ndarray___getbuffer__(PyArrayObject *__pyx_v_self, P
  */
   __pyx_v_info->ndim = __pyx_v_ndim;
 
-  /* ".tox/py37/lib/python3.7/site-packages/Cython/Includes/numpy/__init__.pxd":280
+  /* "../../../pyenv/scikit-allel-py37/lib/python3.7/site-packages/Cython/Includes/numpy/__init__.pxd":280
  *             info.buf = PyArray_DATA(self)
  *             info.ndim = ndim
  *             if sizeof(npy_intp) != sizeof(Py_ssize_t):             # <<<<<<<<<<<<<<
@@ -34020,7 +34020,7 @@ static int __pyx_pf_5numpy_7ndarray___getbuffer__(PyArrayObject *__pyx_v_self, P
   __pyx_t_1 = (((sizeof(npy_intp)) != (sizeof(Py_ssize_t))) != 0);
   if (__pyx_t_1) {
 
-    /* ".tox/py37/lib/python3.7/site-packages/Cython/Includes/numpy/__init__.pxd":283
+    /* "../../../pyenv/scikit-allel-py37/lib/python3.7/site-packages/Cython/Includes/numpy/__init__.pxd":283
  *                 # Allocate new buffer for strides and shape info.
  *                 # This is allocated as one block, strides first.
  *                 info.strides = <Py_ssize_t*>PyObject_Malloc(sizeof(Py_ssize_t) * 2 * <size_t>ndim)             # <<<<<<<<<<<<<<
@@ -34029,7 +34029,7 @@ static int __pyx_pf_5numpy_7ndarray___getbuffer__(PyArrayObject *__pyx_v_self, P
  */
     __pyx_v_info->strides = ((Py_ssize_t *)PyObject_Malloc((((sizeof(Py_ssize_t)) * 2) * ((size_t)__pyx_v_ndim))));
 
-    /* ".tox/py37/lib/python3.7/site-packages/Cython/Includes/numpy/__init__.pxd":284
+    /* "../../../pyenv/scikit-allel-py37/lib/python3.7/site-packages/Cython/Includes/numpy/__init__.pxd":284
  *                 # This is allocated as one block, strides first.
  *                 info.strides = <Py_ssize_t*>PyObject_Malloc(sizeof(Py_ssize_t) * 2 * <size_t>ndim)
  *                 info.shape = info.strides + ndim             # <<<<<<<<<<<<<<
@@ -34038,7 +34038,7 @@ static int __pyx_pf_5numpy_7ndarray___getbuffer__(PyArrayObject *__pyx_v_self, P
  */
     __pyx_v_info->shape = (__pyx_v_info->strides + __pyx_v_ndim);
 
-    /* ".tox/py37/lib/python3.7/site-packages/Cython/Includes/numpy/__init__.pxd":285
+    /* "../../../pyenv/scikit-allel-py37/lib/python3.7/site-packages/Cython/Includes/numpy/__init__.pxd":285
  *                 info.strides = <Py_ssize_t*>PyObject_Malloc(sizeof(Py_ssize_t) * 2 * <size_t>ndim)
  *                 info.shape = info.strides + ndim
  *                 for i in range(ndim):             # <<<<<<<<<<<<<<
@@ -34050,7 +34050,7 @@ static int __pyx_pf_5numpy_7ndarray___getbuffer__(PyArrayObject *__pyx_v_self, P
     for (__pyx_t_6 = 0; __pyx_t_6 < __pyx_t_5; __pyx_t_6+=1) {
       __pyx_v_i = __pyx_t_6;
 
-      /* ".tox/py37/lib/python3.7/site-packages/Cython/Includes/numpy/__init__.pxd":286
+      /* "../../../pyenv/scikit-allel-py37/lib/python3.7/site-packages/Cython/Includes/numpy/__init__.pxd":286
  *                 info.shape = info.strides + ndim
  *                 for i in range(ndim):
  *                     info.strides[i] = PyArray_STRIDES(self)[i]             # <<<<<<<<<<<<<<
@@ -34059,7 +34059,7 @@ static int __pyx_pf_5numpy_7ndarray___getbuffer__(PyArrayObject *__pyx_v_self, P
  */
       (__pyx_v_info->strides[__pyx_v_i]) = (PyArray_STRIDES(__pyx_v_self)[__pyx_v_i]);
 
-      /* ".tox/py37/lib/python3.7/site-packages/Cython/Includes/numpy/__init__.pxd":287
+      /* "../../../pyenv/scikit-allel-py37/lib/python3.7/site-packages/Cython/Includes/numpy/__init__.pxd":287
  *                 for i in range(ndim):
  *                     info.strides[i] = PyArray_STRIDES(self)[i]
  *                     info.shape[i] = PyArray_DIMS(self)[i]             # <<<<<<<<<<<<<<
@@ -34069,7 +34069,7 @@ static int __pyx_pf_5numpy_7ndarray___getbuffer__(PyArrayObject *__pyx_v_self, P
       (__pyx_v_info->shape[__pyx_v_i]) = (PyArray_DIMS(__pyx_v_self)[__pyx_v_i]);
     }
 
-    /* ".tox/py37/lib/python3.7/site-packages/Cython/Includes/numpy/__init__.pxd":280
+    /* "../../../pyenv/scikit-allel-py37/lib/python3.7/site-packages/Cython/Includes/numpy/__init__.pxd":280
  *             info.buf = PyArray_DATA(self)
  *             info.ndim = ndim
  *             if sizeof(npy_intp) != sizeof(Py_ssize_t):             # <<<<<<<<<<<<<<
@@ -34079,7 +34079,7 @@ static int __pyx_pf_5numpy_7ndarray___getbuffer__(PyArrayObject *__pyx_v_self, P
     goto __pyx_L9;
   }
 
-  /* ".tox/py37/lib/python3.7/site-packages/Cython/Includes/numpy/__init__.pxd":289
+  /* "../../../pyenv/scikit-allel-py37/lib/python3.7/site-packages/Cython/Includes/numpy/__init__.pxd":289
  *                     info.shape[i] = PyArray_DIMS(self)[i]
  *             else:
  *                 info.strides = <Py_ssize_t*>PyArray_STRIDES(self)             # <<<<<<<<<<<<<<
@@ -34089,7 +34089,7 @@ static int __pyx_pf_5numpy_7ndarray___getbuffer__(PyArrayObject *__pyx_v_self, P
   /*else*/ {
     __pyx_v_info->strides = ((Py_ssize_t *)PyArray_STRIDES(__pyx_v_self));
 
-    /* ".tox/py37/lib/python3.7/site-packages/Cython/Includes/numpy/__init__.pxd":290
+    /* "../../../pyenv/scikit-allel-py37/lib/python3.7/site-packages/Cython/Includes/numpy/__init__.pxd":290
  *             else:
  *                 info.strides = <Py_ssize_t*>PyArray_STRIDES(self)
  *                 info.shape = <Py_ssize_t*>PyArray_DIMS(self)             # <<<<<<<<<<<<<<
@@ -34100,7 +34100,7 @@ static int __pyx_pf_5numpy_7ndarray___getbuffer__(PyArrayObject *__pyx_v_self, P
   }
   __pyx_L9:;
 
-  /* ".tox/py37/lib/python3.7/site-packages/Cython/Includes/numpy/__init__.pxd":291
+  /* "../../../pyenv/scikit-allel-py37/lib/python3.7/site-packages/Cython/Includes/numpy/__init__.pxd":291
  *                 info.strides = <Py_ssize_t*>PyArray_STRIDES(self)
  *                 info.shape = <Py_ssize_t*>PyArray_DIMS(self)
  *             info.suboffsets = NULL             # <<<<<<<<<<<<<<
@@ -34109,7 +34109,7 @@ static int __pyx_pf_5numpy_7ndarray___getbuffer__(PyArrayObject *__pyx_v_self, P
  */
   __pyx_v_info->suboffsets = NULL;
 
-  /* ".tox/py37/lib/python3.7/site-packages/Cython/Includes/numpy/__init__.pxd":292
+  /* "../../../pyenv/scikit-allel-py37/lib/python3.7/site-packages/Cython/Includes/numpy/__init__.pxd":292
  *                 info.shape = <Py_ssize_t*>PyArray_DIMS(self)
  *             info.suboffsets = NULL
  *             info.itemsize = PyArray_ITEMSIZE(self)             # <<<<<<<<<<<<<<
@@ -34118,7 +34118,7 @@ static int __pyx_pf_5numpy_7ndarray___getbuffer__(PyArrayObject *__pyx_v_self, P
  */
   __pyx_v_info->itemsize = PyArray_ITEMSIZE(__pyx_v_self);
 
-  /* ".tox/py37/lib/python3.7/site-packages/Cython/Includes/numpy/__init__.pxd":293
+  /* "../../../pyenv/scikit-allel-py37/lib/python3.7/site-packages/Cython/Includes/numpy/__init__.pxd":293
  *             info.suboffsets = NULL
  *             info.itemsize = PyArray_ITEMSIZE(self)
  *             info.readonly = not PyArray_ISWRITEABLE(self)             # <<<<<<<<<<<<<<
@@ -34127,7 +34127,7 @@ static int __pyx_pf_5numpy_7ndarray___getbuffer__(PyArrayObject *__pyx_v_self, P
  */
   __pyx_v_info->readonly = (!(PyArray_ISWRITEABLE(__pyx_v_self) != 0));
 
-  /* ".tox/py37/lib/python3.7/site-packages/Cython/Includes/numpy/__init__.pxd":296
+  /* "../../../pyenv/scikit-allel-py37/lib/python3.7/site-packages/Cython/Includes/numpy/__init__.pxd":296
  * 
  *             cdef int t
  *             cdef char* f = NULL             # <<<<<<<<<<<<<<
@@ -34136,7 +34136,7 @@ static int __pyx_pf_5numpy_7ndarray___getbuffer__(PyArrayObject *__pyx_v_self, P
  */
   __pyx_v_f = NULL;
 
-  /* ".tox/py37/lib/python3.7/site-packages/Cython/Includes/numpy/__init__.pxd":297
+  /* "../../../pyenv/scikit-allel-py37/lib/python3.7/site-packages/Cython/Includes/numpy/__init__.pxd":297
  *             cdef int t
  *             cdef char* f = NULL
  *             cdef dtype descr = <dtype>PyArray_DESCR(self)             # <<<<<<<<<<<<<<
@@ -34149,7 +34149,7 @@ static int __pyx_pf_5numpy_7ndarray___getbuffer__(PyArrayObject *__pyx_v_self, P
   __pyx_v_descr = ((PyArray_Descr *)__pyx_t_3);
   __pyx_t_3 = 0;
 
-  /* ".tox/py37/lib/python3.7/site-packages/Cython/Includes/numpy/__init__.pxd":300
+  /* "../../../pyenv/scikit-allel-py37/lib/python3.7/site-packages/Cython/Includes/numpy/__init__.pxd":300
  *             cdef int offset
  * 
  *             info.obj = self             # <<<<<<<<<<<<<<
@@ -34162,7 +34162,7 @@ static int __pyx_pf_5numpy_7ndarray___getbuffer__(PyArrayObject *__pyx_v_self, P
   __Pyx_DECREF(__pyx_v_info->obj);
   __pyx_v_info->obj = ((PyObject *)__pyx_v_self);
 
-  /* ".tox/py37/lib/python3.7/site-packages/Cython/Includes/numpy/__init__.pxd":302
+  /* "../../../pyenv/scikit-allel-py37/lib/python3.7/site-packages/Cython/Includes/numpy/__init__.pxd":302
  *             info.obj = self
  * 
  *             if not PyDataType_HASFIELDS(descr):             # <<<<<<<<<<<<<<
@@ -34172,7 +34172,7 @@ static int __pyx_pf_5numpy_7ndarray___getbuffer__(PyArrayObject *__pyx_v_self, P
   __pyx_t_1 = ((!(PyDataType_HASFIELDS(__pyx_v_descr) != 0)) != 0);
   if (__pyx_t_1) {
 
-    /* ".tox/py37/lib/python3.7/site-packages/Cython/Includes/numpy/__init__.pxd":303
+    /* "../../../pyenv/scikit-allel-py37/lib/python3.7/site-packages/Cython/Includes/numpy/__init__.pxd":303
  * 
  *             if not PyDataType_HASFIELDS(descr):
  *                 t = descr.type_num             # <<<<<<<<<<<<<<
@@ -34182,7 +34182,7 @@ static int __pyx_pf_5numpy_7ndarray___getbuffer__(PyArrayObject *__pyx_v_self, P
     __pyx_t_4 = __pyx_v_descr->type_num;
     __pyx_v_t = __pyx_t_4;
 
-    /* ".tox/py37/lib/python3.7/site-packages/Cython/Includes/numpy/__init__.pxd":304
+    /* "../../../pyenv/scikit-allel-py37/lib/python3.7/site-packages/Cython/Includes/numpy/__init__.pxd":304
  *             if not PyDataType_HASFIELDS(descr):
  *                 t = descr.type_num
  *                 if ((descr.byteorder == c'>' and little_endian) or             # <<<<<<<<<<<<<<
@@ -34202,7 +34202,7 @@ static int __pyx_pf_5numpy_7ndarray___getbuffer__(PyArrayObject *__pyx_v_self, P
     }
     __pyx_L15_next_or:;
 
-    /* ".tox/py37/lib/python3.7/site-packages/Cython/Includes/numpy/__init__.pxd":305
+    /* "../../../pyenv/scikit-allel-py37/lib/python3.7/site-packages/Cython/Includes/numpy/__init__.pxd":305
  *                 t = descr.type_num
  *                 if ((descr.byteorder == c'>' and little_endian) or
  *                     (descr.byteorder == c'<' and not little_endian)):             # <<<<<<<<<<<<<<
@@ -34219,7 +34219,7 @@ static int __pyx_pf_5numpy_7ndarray___getbuffer__(PyArrayObject *__pyx_v_self, P
     __pyx_t_1 = __pyx_t_2;
     __pyx_L14_bool_binop_done:;
 
-    /* ".tox/py37/lib/python3.7/site-packages/Cython/Includes/numpy/__init__.pxd":304
+    /* "../../../pyenv/scikit-allel-py37/lib/python3.7/site-packages/Cython/Includes/numpy/__init__.pxd":304
  *             if not PyDataType_HASFIELDS(descr):
  *                 t = descr.type_num
  *                 if ((descr.byteorder == c'>' and little_endian) or             # <<<<<<<<<<<<<<
@@ -34228,7 +34228,7 @@ static int __pyx_pf_5numpy_7ndarray___getbuffer__(PyArrayObject *__pyx_v_self, P
  */
     if (unlikely(__pyx_t_1)) {
 
-      /* ".tox/py37/lib/python3.7/site-packages/Cython/Includes/numpy/__init__.pxd":306
+      /* "../../../pyenv/scikit-allel-py37/lib/python3.7/site-packages/Cython/Includes/numpy/__init__.pxd":306
  *                 if ((descr.byteorder == c'>' and little_endian) or
  *                     (descr.byteorder == c'<' and not little_endian)):
  *                     raise ValueError(u"Non-native byte order not supported")             # <<<<<<<<<<<<<<
@@ -34241,7 +34241,7 @@ static int __pyx_pf_5numpy_7ndarray___getbuffer__(PyArrayObject *__pyx_v_self, P
       __Pyx_DECREF(__pyx_t_3); __pyx_t_3 = 0;
       __PYX_ERR(1, 306, __pyx_L1_error)
 
-      /* ".tox/py37/lib/python3.7/site-packages/Cython/Includes/numpy/__init__.pxd":304
+      /* "../../../pyenv/scikit-allel-py37/lib/python3.7/site-packages/Cython/Includes/numpy/__init__.pxd":304
  *             if not PyDataType_HASFIELDS(descr):
  *                 t = descr.type_num
  *                 if ((descr.byteorder == c'>' and little_endian) or             # <<<<<<<<<<<<<<
@@ -34250,7 +34250,7 @@ static int __pyx_pf_5numpy_7ndarray___getbuffer__(PyArrayObject *__pyx_v_self, P
  */
     }
 
-    /* ".tox/py37/lib/python3.7/site-packages/Cython/Includes/numpy/__init__.pxd":307
+    /* "../../../pyenv/scikit-allel-py37/lib/python3.7/site-packages/Cython/Includes/numpy/__init__.pxd":307
  *                     (descr.byteorder == c'<' and not little_endian)):
  *                     raise ValueError(u"Non-native byte order not supported")
  *                 if   t == NPY_BYTE:        f = "b"             # <<<<<<<<<<<<<<
@@ -34263,7 +34263,7 @@ static int __pyx_pf_5numpy_7ndarray___getbuffer__(PyArrayObject *__pyx_v_self, P
       break;
       case NPY_UBYTE:
 
-      /* ".tox/py37/lib/python3.7/site-packages/Cython/Includes/numpy/__init__.pxd":308
+      /* "../../../pyenv/scikit-allel-py37/lib/python3.7/site-packages/Cython/Includes/numpy/__init__.pxd":308
  *                     raise ValueError(u"Non-native byte order not supported")
  *                 if   t == NPY_BYTE:        f = "b"
  *                 elif t == NPY_UBYTE:       f = "B"             # <<<<<<<<<<<<<<
@@ -34274,7 +34274,7 @@ static int __pyx_pf_5numpy_7ndarray___getbuffer__(PyArrayObject *__pyx_v_self, P
       break;
       case NPY_SHORT:
 
-      /* ".tox/py37/lib/python3.7/site-packages/Cython/Includes/numpy/__init__.pxd":309
+      /* "../../../pyenv/scikit-allel-py37/lib/python3.7/site-packages/Cython/Includes/numpy/__init__.pxd":309
  *                 if   t == NPY_BYTE:        f = "b"
  *                 elif t == NPY_UBYTE:       f = "B"
  *                 elif t == NPY_SHORT:       f = "h"             # <<<<<<<<<<<<<<
@@ -34285,7 +34285,7 @@ static int __pyx_pf_5numpy_7ndarray___getbuffer__(PyArrayObject *__pyx_v_self, P
       break;
       case NPY_USHORT:
 
-      /* ".tox/py37/lib/python3.7/site-packages/Cython/Includes/numpy/__init__.pxd":310
+      /* "../../../pyenv/scikit-allel-py37/lib/python3.7/site-packages/Cython/Includes/numpy/__init__.pxd":310
  *                 elif t == NPY_UBYTE:       f = "B"
  *                 elif t == NPY_SHORT:       f = "h"
  *                 elif t == NPY_USHORT:      f = "H"             # <<<<<<<<<<<<<<
@@ -34296,7 +34296,7 @@ static int __pyx_pf_5numpy_7ndarray___getbuffer__(PyArrayObject *__pyx_v_self, P
       break;
       case NPY_INT:
 
-      /* ".tox/py37/lib/python3.7/site-packages/Cython/Includes/numpy/__init__.pxd":311
+      /* "../../../pyenv/scikit-allel-py37/lib/python3.7/site-packages/Cython/Includes/numpy/__init__.pxd":311
  *                 elif t == NPY_SHORT:       f = "h"
  *                 elif t == NPY_USHORT:      f = "H"
  *                 elif t == NPY_INT:         f = "i"             # <<<<<<<<<<<<<<
@@ -34307,7 +34307,7 @@ static int __pyx_pf_5numpy_7ndarray___getbuffer__(PyArrayObject *__pyx_v_self, P
       break;
       case NPY_UINT:
 
-      /* ".tox/py37/lib/python3.7/site-packages/Cython/Includes/numpy/__init__.pxd":312
+      /* "../../../pyenv/scikit-allel-py37/lib/python3.7/site-packages/Cython/Includes/numpy/__init__.pxd":312
  *                 elif t == NPY_USHORT:      f = "H"
  *                 elif t == NPY_INT:         f = "i"
  *                 elif t == NPY_UINT:        f = "I"             # <<<<<<<<<<<<<<
@@ -34318,7 +34318,7 @@ static int __pyx_pf_5numpy_7ndarray___getbuffer__(PyArrayObject *__pyx_v_self, P
       break;
       case NPY_LONG:
 
-      /* ".tox/py37/lib/python3.7/site-packages/Cython/Includes/numpy/__init__.pxd":313
+      /* "../../../pyenv/scikit-allel-py37/lib/python3.7/site-packages/Cython/Includes/numpy/__init__.pxd":313
  *                 elif t == NPY_INT:         f = "i"
  *                 elif t == NPY_UINT:        f = "I"
  *                 elif t == NPY_LONG:        f = "l"             # <<<<<<<<<<<<<<
@@ -34329,7 +34329,7 @@ static int __pyx_pf_5numpy_7ndarray___getbuffer__(PyArrayObject *__pyx_v_self, P
       break;
       case NPY_ULONG:
 
-      /* ".tox/py37/lib/python3.7/site-packages/Cython/Includes/numpy/__init__.pxd":314
+      /* "../../../pyenv/scikit-allel-py37/lib/python3.7/site-packages/Cython/Includes/numpy/__init__.pxd":314
  *                 elif t == NPY_UINT:        f = "I"
  *                 elif t == NPY_LONG:        f = "l"
  *                 elif t == NPY_ULONG:       f = "L"             # <<<<<<<<<<<<<<
@@ -34340,7 +34340,7 @@ static int __pyx_pf_5numpy_7ndarray___getbuffer__(PyArrayObject *__pyx_v_self, P
       break;
       case NPY_LONGLONG:
 
-      /* ".tox/py37/lib/python3.7/site-packages/Cython/Includes/numpy/__init__.pxd":315
+      /* "../../../pyenv/scikit-allel-py37/lib/python3.7/site-packages/Cython/Includes/numpy/__init__.pxd":315
  *                 elif t == NPY_LONG:        f = "l"
  *                 elif t == NPY_ULONG:       f = "L"
  *                 elif t == NPY_LONGLONG:    f = "q"             # <<<<<<<<<<<<<<
@@ -34351,7 +34351,7 @@ static int __pyx_pf_5numpy_7ndarray___getbuffer__(PyArrayObject *__pyx_v_self, P
       break;
       case NPY_ULONGLONG:
 
-      /* ".tox/py37/lib/python3.7/site-packages/Cython/Includes/numpy/__init__.pxd":316
+      /* "../../../pyenv/scikit-allel-py37/lib/python3.7/site-packages/Cython/Includes/numpy/__init__.pxd":316
  *                 elif t == NPY_ULONG:       f = "L"
  *                 elif t == NPY_LONGLONG:    f = "q"
  *                 elif t == NPY_ULONGLONG:   f = "Q"             # <<<<<<<<<<<<<<
@@ -34362,7 +34362,7 @@ static int __pyx_pf_5numpy_7ndarray___getbuffer__(PyArrayObject *__pyx_v_self, P
       break;
       case NPY_FLOAT:
 
-      /* ".tox/py37/lib/python3.7/site-packages/Cython/Includes/numpy/__init__.pxd":317
+      /* "../../../pyenv/scikit-allel-py37/lib/python3.7/site-packages/Cython/Includes/numpy/__init__.pxd":317
  *                 elif t == NPY_LONGLONG:    f = "q"
  *                 elif t == NPY_ULONGLONG:   f = "Q"
  *                 elif t == NPY_FLOAT:       f = "f"             # <<<<<<<<<<<<<<
@@ -34373,7 +34373,7 @@ static int __pyx_pf_5numpy_7ndarray___getbuffer__(PyArrayObject *__pyx_v_self, P
       break;
       case NPY_DOUBLE:
 
-      /* ".tox/py37/lib/python3.7/site-packages/Cython/Includes/numpy/__init__.pxd":318
+      /* "../../../pyenv/scikit-allel-py37/lib/python3.7/site-packages/Cython/Includes/numpy/__init__.pxd":318
  *                 elif t == NPY_ULONGLONG:   f = "Q"
  *                 elif t == NPY_FLOAT:       f = "f"
  *                 elif t == NPY_DOUBLE:      f = "d"             # <<<<<<<<<<<<<<
@@ -34384,7 +34384,7 @@ static int __pyx_pf_5numpy_7ndarray___getbuffer__(PyArrayObject *__pyx_v_self, P
       break;
       case NPY_LONGDOUBLE:
 
-      /* ".tox/py37/lib/python3.7/site-packages/Cython/Includes/numpy/__init__.pxd":319
+      /* "../../../pyenv/scikit-allel-py37/lib/python3.7/site-packages/Cython/Includes/numpy/__init__.pxd":319
  *                 elif t == NPY_FLOAT:       f = "f"
  *                 elif t == NPY_DOUBLE:      f = "d"
  *                 elif t == NPY_LONGDOUBLE:  f = "g"             # <<<<<<<<<<<<<<
@@ -34395,7 +34395,7 @@ static int __pyx_pf_5numpy_7ndarray___getbuffer__(PyArrayObject *__pyx_v_self, P
       break;
       case NPY_CFLOAT:
 
-      /* ".tox/py37/lib/python3.7/site-packages/Cython/Includes/numpy/__init__.pxd":320
+      /* "../../../pyenv/scikit-allel-py37/lib/python3.7/site-packages/Cython/Includes/numpy/__init__.pxd":320
  *                 elif t == NPY_DOUBLE:      f = "d"
  *                 elif t == NPY_LONGDOUBLE:  f = "g"
  *                 elif t == NPY_CFLOAT:      f = "Zf"             # <<<<<<<<<<<<<<
@@ -34406,7 +34406,7 @@ static int __pyx_pf_5numpy_7ndarray___getbuffer__(PyArrayObject *__pyx_v_self, P
       break;
       case NPY_CDOUBLE:
 
-      /* ".tox/py37/lib/python3.7/site-packages/Cython/Includes/numpy/__init__.pxd":321
+      /* "../../../pyenv/scikit-allel-py37/lib/python3.7/site-packages/Cython/Includes/numpy/__init__.pxd":321
  *                 elif t == NPY_LONGDOUBLE:  f = "g"
  *                 elif t == NPY_CFLOAT:      f = "Zf"
  *                 elif t == NPY_CDOUBLE:     f = "Zd"             # <<<<<<<<<<<<<<
@@ -34417,7 +34417,7 @@ static int __pyx_pf_5numpy_7ndarray___getbuffer__(PyArrayObject *__pyx_v_self, P
       break;
       case NPY_CLONGDOUBLE:
 
-      /* ".tox/py37/lib/python3.7/site-packages/Cython/Includes/numpy/__init__.pxd":322
+      /* "../../../pyenv/scikit-allel-py37/lib/python3.7/site-packages/Cython/Includes/numpy/__init__.pxd":322
  *                 elif t == NPY_CFLOAT:      f = "Zf"
  *                 elif t == NPY_CDOUBLE:     f = "Zd"
  *                 elif t == NPY_CLONGDOUBLE: f = "Zg"             # <<<<<<<<<<<<<<
@@ -34428,7 +34428,7 @@ static int __pyx_pf_5numpy_7ndarray___getbuffer__(PyArrayObject *__pyx_v_self, P
       break;
       case NPY_OBJECT:
 
-      /* ".tox/py37/lib/python3.7/site-packages/Cython/Includes/numpy/__init__.pxd":323
+      /* "../../../pyenv/scikit-allel-py37/lib/python3.7/site-packages/Cython/Includes/numpy/__init__.pxd":323
  *                 elif t == NPY_CDOUBLE:     f = "Zd"
  *                 elif t == NPY_CLONGDOUBLE: f = "Zg"
  *                 elif t == NPY_OBJECT:      f = "O"             # <<<<<<<<<<<<<<
@@ -34439,7 +34439,7 @@ static int __pyx_pf_5numpy_7ndarray___getbuffer__(PyArrayObject *__pyx_v_self, P
       break;
       default:
 
-      /* ".tox/py37/lib/python3.7/site-packages/Cython/Includes/numpy/__init__.pxd":325
+      /* "../../../pyenv/scikit-allel-py37/lib/python3.7/site-packages/Cython/Includes/numpy/__init__.pxd":325
  *                 elif t == NPY_OBJECT:      f = "O"
  *                 else:
  *                     raise ValueError(u"unknown dtype code in numpy.pxd (%d)" % t)             # <<<<<<<<<<<<<<
@@ -34460,7 +34460,7 @@ static int __pyx_pf_5numpy_7ndarray___getbuffer__(PyArrayObject *__pyx_v_self, P
       break;
     }
 
-    /* ".tox/py37/lib/python3.7/site-packages/Cython/Includes/numpy/__init__.pxd":326
+    /* "../../../pyenv/scikit-allel-py37/lib/python3.7/site-packages/Cython/Includes/numpy/__init__.pxd":326
  *                 else:
  *                     raise ValueError(u"unknown dtype code in numpy.pxd (%d)" % t)
  *                 info.format = f             # <<<<<<<<<<<<<<
@@ -34469,7 +34469,7 @@ static int __pyx_pf_5numpy_7ndarray___getbuffer__(PyArrayObject *__pyx_v_self, P
  */
     __pyx_v_info->format = __pyx_v_f;
 
-    /* ".tox/py37/lib/python3.7/site-packages/Cython/Includes/numpy/__init__.pxd":327
+    /* "../../../pyenv/scikit-allel-py37/lib/python3.7/site-packages/Cython/Includes/numpy/__init__.pxd":327
  *                     raise ValueError(u"unknown dtype code in numpy.pxd (%d)" % t)
  *                 info.format = f
  *                 return             # <<<<<<<<<<<<<<
@@ -34479,7 +34479,7 @@ static int __pyx_pf_5numpy_7ndarray___getbuffer__(PyArrayObject *__pyx_v_self, P
     __pyx_r = 0;
     goto __pyx_L0;
 
-    /* ".tox/py37/lib/python3.7/site-packages/Cython/Includes/numpy/__init__.pxd":302
+    /* "../../../pyenv/scikit-allel-py37/lib/python3.7/site-packages/Cython/Includes/numpy/__init__.pxd":302
  *             info.obj = self
  * 
  *             if not PyDataType_HASFIELDS(descr):             # <<<<<<<<<<<<<<
@@ -34488,7 +34488,7 @@ static int __pyx_pf_5numpy_7ndarray___getbuffer__(PyArrayObject *__pyx_v_self, P
  */
   }
 
-  /* ".tox/py37/lib/python3.7/site-packages/Cython/Includes/numpy/__init__.pxd":329
+  /* "../../../pyenv/scikit-allel-py37/lib/python3.7/site-packages/Cython/Includes/numpy/__init__.pxd":329
  *                 return
  *             else:
  *                 info.format = <char*>PyObject_Malloc(_buffer_format_string_len)             # <<<<<<<<<<<<<<
@@ -34498,7 +34498,7 @@ static int __pyx_pf_5numpy_7ndarray___getbuffer__(PyArrayObject *__pyx_v_self, P
   /*else*/ {
     __pyx_v_info->format = ((char *)PyObject_Malloc(0xFF));
 
-    /* ".tox/py37/lib/python3.7/site-packages/Cython/Includes/numpy/__init__.pxd":330
+    /* "../../../pyenv/scikit-allel-py37/lib/python3.7/site-packages/Cython/Includes/numpy/__init__.pxd":330
  *             else:
  *                 info.format = <char*>PyObject_Malloc(_buffer_format_string_len)
  *                 info.format[0] = c'^' # Native data types, manual alignment             # <<<<<<<<<<<<<<
@@ -34507,7 +34507,7 @@ static int __pyx_pf_5numpy_7ndarray___getbuffer__(PyArrayObject *__pyx_v_self, P
  */
     (__pyx_v_info->format[0]) = '^';
 
-    /* ".tox/py37/lib/python3.7/site-packages/Cython/Includes/numpy/__init__.pxd":331
+    /* "../../../pyenv/scikit-allel-py37/lib/python3.7/site-packages/Cython/Includes/numpy/__init__.pxd":331
  *                 info.format = <char*>PyObject_Malloc(_buffer_format_string_len)
  *                 info.format[0] = c'^' # Native data types, manual alignment
  *                 offset = 0             # <<<<<<<<<<<<<<
@@ -34516,7 +34516,7 @@ static int __pyx_pf_5numpy_7ndarray___getbuffer__(PyArrayObject *__pyx_v_self, P
  */
     __pyx_v_offset = 0;
 
-    /* ".tox/py37/lib/python3.7/site-packages/Cython/Includes/numpy/__init__.pxd":332
+    /* "../../../pyenv/scikit-allel-py37/lib/python3.7/site-packages/Cython/Includes/numpy/__init__.pxd":332
  *                 info.format[0] = c'^' # Native data types, manual alignment
  *                 offset = 0
  *                 f = _util_dtypestring(descr, info.format + 1,             # <<<<<<<<<<<<<<
@@ -34526,7 +34526,7 @@ static int __pyx_pf_5numpy_7ndarray___getbuffer__(PyArrayObject *__pyx_v_self, P
     __pyx_t_9 = __pyx_f_5numpy__util_dtypestring(__pyx_v_descr, (__pyx_v_info->format + 1), (__pyx_v_info->format + 0xFF), (&__pyx_v_offset)); if (unlikely(__pyx_t_9 == ((char *)NULL))) __PYX_ERR(1, 332, __pyx_L1_error)
     __pyx_v_f = __pyx_t_9;
 
-    /* ".tox/py37/lib/python3.7/site-packages/Cython/Includes/numpy/__init__.pxd":335
+    /* "../../../pyenv/scikit-allel-py37/lib/python3.7/site-packages/Cython/Includes/numpy/__init__.pxd":335
  *                                       info.format + _buffer_format_string_len,
  *                                       &offset)
  *                 f[0] = c'\0' # Terminate format string             # <<<<<<<<<<<<<<
@@ -34536,7 +34536,7 @@ static int __pyx_pf_5numpy_7ndarray___getbuffer__(PyArrayObject *__pyx_v_self, P
     (__pyx_v_f[0]) = '\x00';
   }
 
-  /* ".tox/py37/lib/python3.7/site-packages/Cython/Includes/numpy/__init__.pxd":258
+  /* "../../../pyenv/scikit-allel-py37/lib/python3.7/site-packages/Cython/Includes/numpy/__init__.pxd":258
  *         # experimental exception made for __getbuffer__ and __releasebuffer__
  *         # -- the details of this may change.
  *         def __getbuffer__(ndarray self, Py_buffer* info, int flags):             # <<<<<<<<<<<<<<
@@ -34568,7 +34568,7 @@ static int __pyx_pf_5numpy_7ndarray___getbuffer__(PyArrayObject *__pyx_v_self, P
   return __pyx_r;
 }
 
-/* ".tox/py37/lib/python3.7/site-packages/Cython/Includes/numpy/__init__.pxd":337
+/* "../../../pyenv/scikit-allel-py37/lib/python3.7/site-packages/Cython/Includes/numpy/__init__.pxd":337
  *                 f[0] = c'\0' # Terminate format string
  * 
  *         def __releasebuffer__(ndarray self, Py_buffer* info):             # <<<<<<<<<<<<<<
@@ -34592,7 +34592,7 @@ static void __pyx_pf_5numpy_7ndarray_2__releasebuffer__(PyArrayObject *__pyx_v_s
   int __pyx_t_1;
   __Pyx_RefNannySetupContext("__releasebuffer__", 0);
 
-  /* ".tox/py37/lib/python3.7/site-packages/Cython/Includes/numpy/__init__.pxd":338
+  /* "../../../pyenv/scikit-allel-py37/lib/python3.7/site-packages/Cython/Includes/numpy/__init__.pxd":338
  * 
  *         def __releasebuffer__(ndarray self, Py_buffer* info):
  *             if PyArray_HASFIELDS(self):             # <<<<<<<<<<<<<<
@@ -34602,7 +34602,7 @@ static void __pyx_pf_5numpy_7ndarray_2__releasebuffer__(PyArrayObject *__pyx_v_s
   __pyx_t_1 = (PyArray_HASFIELDS(__pyx_v_self) != 0);
   if (__pyx_t_1) {
 
-    /* ".tox/py37/lib/python3.7/site-packages/Cython/Includes/numpy/__init__.pxd":339
+    /* "../../../pyenv/scikit-allel-py37/lib/python3.7/site-packages/Cython/Includes/numpy/__init__.pxd":339
  *         def __releasebuffer__(ndarray self, Py_buffer* info):
  *             if PyArray_HASFIELDS(self):
  *                 PyObject_Free(info.format)             # <<<<<<<<<<<<<<
@@ -34611,7 +34611,7 @@ static void __pyx_pf_5numpy_7ndarray_2__releasebuffer__(PyArrayObject *__pyx_v_s
  */
     PyObject_Free(__pyx_v_info->format);
 
-    /* ".tox/py37/lib/python3.7/site-packages/Cython/Includes/numpy/__init__.pxd":338
+    /* "../../../pyenv/scikit-allel-py37/lib/python3.7/site-packages/Cython/Includes/numpy/__init__.pxd":338
  * 
  *         def __releasebuffer__(ndarray self, Py_buffer* info):
  *             if PyArray_HASFIELDS(self):             # <<<<<<<<<<<<<<
@@ -34620,7 +34620,7 @@ static void __pyx_pf_5numpy_7ndarray_2__releasebuffer__(PyArrayObject *__pyx_v_s
  */
   }
 
-  /* ".tox/py37/lib/python3.7/site-packages/Cython/Includes/numpy/__init__.pxd":340
+  /* "../../../pyenv/scikit-allel-py37/lib/python3.7/site-packages/Cython/Includes/numpy/__init__.pxd":340
  *             if PyArray_HASFIELDS(self):
  *                 PyObject_Free(info.format)
  *             if sizeof(npy_intp) != sizeof(Py_ssize_t):             # <<<<<<<<<<<<<<
@@ -34630,7 +34630,7 @@ static void __pyx_pf_5numpy_7ndarray_2__releasebuffer__(PyArrayObject *__pyx_v_s
   __pyx_t_1 = (((sizeof(npy_intp)) != (sizeof(Py_ssize_t))) != 0);
   if (__pyx_t_1) {
 
-    /* ".tox/py37/lib/python3.7/site-packages/Cython/Includes/numpy/__init__.pxd":341
+    /* "../../../pyenv/scikit-allel-py37/lib/python3.7/site-packages/Cython/Includes/numpy/__init__.pxd":341
  *                 PyObject_Free(info.format)
  *             if sizeof(npy_intp) != sizeof(Py_ssize_t):
  *                 PyObject_Free(info.strides)             # <<<<<<<<<<<<<<
@@ -34639,7 +34639,7 @@ static void __pyx_pf_5numpy_7ndarray_2__releasebuffer__(PyArrayObject *__pyx_v_s
  */
     PyObject_Free(__pyx_v_info->strides);
 
-    /* ".tox/py37/lib/python3.7/site-packages/Cython/Includes/numpy/__init__.pxd":340
+    /* "../../../pyenv/scikit-allel-py37/lib/python3.7/site-packages/Cython/Includes/numpy/__init__.pxd":340
  *             if PyArray_HASFIELDS(self):
  *                 PyObject_Free(info.format)
  *             if sizeof(npy_intp) != sizeof(Py_ssize_t):             # <<<<<<<<<<<<<<
@@ -34648,7 +34648,7 @@ static void __pyx_pf_5numpy_7ndarray_2__releasebuffer__(PyArrayObject *__pyx_v_s
  */
   }
 
-  /* ".tox/py37/lib/python3.7/site-packages/Cython/Includes/numpy/__init__.pxd":337
+  /* "../../../pyenv/scikit-allel-py37/lib/python3.7/site-packages/Cython/Includes/numpy/__init__.pxd":337
  *                 f[0] = c'\0' # Terminate format string
  * 
  *         def __releasebuffer__(ndarray self, Py_buffer* info):             # <<<<<<<<<<<<<<
@@ -34660,7 +34660,7 @@ static void __pyx_pf_5numpy_7ndarray_2__releasebuffer__(PyArrayObject *__pyx_v_s
   __Pyx_RefNannyFinishContext();
 }
 
-/* ".tox/py37/lib/python3.7/site-packages/Cython/Includes/numpy/__init__.pxd":821
+/* "../../../pyenv/scikit-allel-py37/lib/python3.7/site-packages/Cython/Includes/numpy/__init__.pxd":821
  * ctypedef npy_cdouble     complex_t
  * 
  * cdef inline object PyArray_MultiIterNew1(a):             # <<<<<<<<<<<<<<
@@ -34674,7 +34674,7 @@ static CYTHON_INLINE PyObject *__pyx_f_5numpy_PyArray_MultiIterNew1(PyObject *__
   PyObject *__pyx_t_1 = NULL;
   __Pyx_RefNannySetupContext("PyArray_MultiIterNew1", 0);
 
-  /* ".tox/py37/lib/python3.7/site-packages/Cython/Includes/numpy/__init__.pxd":822
+  /* "../../../pyenv/scikit-allel-py37/lib/python3.7/site-packages/Cython/Includes/numpy/__init__.pxd":822
  * 
  * cdef inline object PyArray_MultiIterNew1(a):
  *     return PyArray_MultiIterNew(1, <void*>a)             # <<<<<<<<<<<<<<
@@ -34688,7 +34688,7 @@ static CYTHON_INLINE PyObject *__pyx_f_5numpy_PyArray_MultiIterNew1(PyObject *__
   __pyx_t_1 = 0;
   goto __pyx_L0;
 
-  /* ".tox/py37/lib/python3.7/site-packages/Cython/Includes/numpy/__init__.pxd":821
+  /* "../../../pyenv/scikit-allel-py37/lib/python3.7/site-packages/Cython/Includes/numpy/__init__.pxd":821
  * ctypedef npy_cdouble     complex_t
  * 
  * cdef inline object PyArray_MultiIterNew1(a):             # <<<<<<<<<<<<<<
@@ -34707,7 +34707,7 @@ static CYTHON_INLINE PyObject *__pyx_f_5numpy_PyArray_MultiIterNew1(PyObject *__
   return __pyx_r;
 }
 
-/* ".tox/py37/lib/python3.7/site-packages/Cython/Includes/numpy/__init__.pxd":824
+/* "../../../pyenv/scikit-allel-py37/lib/python3.7/site-packages/Cython/Includes/numpy/__init__.pxd":824
  *     return PyArray_MultiIterNew(1, <void*>a)
  * 
  * cdef inline object PyArray_MultiIterNew2(a, b):             # <<<<<<<<<<<<<<
@@ -34721,7 +34721,7 @@ static CYTHON_INLINE PyObject *__pyx_f_5numpy_PyArray_MultiIterNew2(PyObject *__
   PyObject *__pyx_t_1 = NULL;
   __Pyx_RefNannySetupContext("PyArray_MultiIterNew2", 0);
 
-  /* ".tox/py37/lib/python3.7/site-packages/Cython/Includes/numpy/__init__.pxd":825
+  /* "../../../pyenv/scikit-allel-py37/lib/python3.7/site-packages/Cython/Includes/numpy/__init__.pxd":825
  * 
  * cdef inline object PyArray_MultiIterNew2(a, b):
  *     return PyArray_MultiIterNew(2, <void*>a, <void*>b)             # <<<<<<<<<<<<<<
@@ -34735,7 +34735,7 @@ static CYTHON_INLINE PyObject *__pyx_f_5numpy_PyArray_MultiIterNew2(PyObject *__
   __pyx_t_1 = 0;
   goto __pyx_L0;
 
-  /* ".tox/py37/lib/python3.7/site-packages/Cython/Includes/numpy/__init__.pxd":824
+  /* "../../../pyenv/scikit-allel-py37/lib/python3.7/site-packages/Cython/Includes/numpy/__init__.pxd":824
  *     return PyArray_MultiIterNew(1, <void*>a)
  * 
  * cdef inline object PyArray_MultiIterNew2(a, b):             # <<<<<<<<<<<<<<
@@ -34754,7 +34754,7 @@ static CYTHON_INLINE PyObject *__pyx_f_5numpy_PyArray_MultiIterNew2(PyObject *__
   return __pyx_r;
 }
 
-/* ".tox/py37/lib/python3.7/site-packages/Cython/Includes/numpy/__init__.pxd":827
+/* "../../../pyenv/scikit-allel-py37/lib/python3.7/site-packages/Cython/Includes/numpy/__init__.pxd":827
  *     return PyArray_MultiIterNew(2, <void*>a, <void*>b)
  * 
  * cdef inline object PyArray_MultiIterNew3(a, b, c):             # <<<<<<<<<<<<<<
@@ -34768,7 +34768,7 @@ static CYTHON_INLINE PyObject *__pyx_f_5numpy_PyArray_MultiIterNew3(PyObject *__
   PyObject *__pyx_t_1 = NULL;
   __Pyx_RefNannySetupContext("PyArray_MultiIterNew3", 0);
 
-  /* ".tox/py37/lib/python3.7/site-packages/Cython/Includes/numpy/__init__.pxd":828
+  /* "../../../pyenv/scikit-allel-py37/lib/python3.7/site-packages/Cython/Includes/numpy/__init__.pxd":828
  * 
  * cdef inline object PyArray_MultiIterNew3(a, b, c):
  *     return PyArray_MultiIterNew(3, <void*>a, <void*>b, <void*> c)             # <<<<<<<<<<<<<<
@@ -34782,7 +34782,7 @@ static CYTHON_INLINE PyObject *__pyx_f_5numpy_PyArray_MultiIterNew3(PyObject *__
   __pyx_t_1 = 0;
   goto __pyx_L0;
 
-  /* ".tox/py37/lib/python3.7/site-packages/Cython/Includes/numpy/__init__.pxd":827
+  /* "../../../pyenv/scikit-allel-py37/lib/python3.7/site-packages/Cython/Includes/numpy/__init__.pxd":827
  *     return PyArray_MultiIterNew(2, <void*>a, <void*>b)
  * 
  * cdef inline object PyArray_MultiIterNew3(a, b, c):             # <<<<<<<<<<<<<<
@@ -34801,7 +34801,7 @@ static CYTHON_INLINE PyObject *__pyx_f_5numpy_PyArray_MultiIterNew3(PyObject *__
   return __pyx_r;
 }
 
-/* ".tox/py37/lib/python3.7/site-packages/Cython/Includes/numpy/__init__.pxd":830
+/* "../../../pyenv/scikit-allel-py37/lib/python3.7/site-packages/Cython/Includes/numpy/__init__.pxd":830
  *     return PyArray_MultiIterNew(3, <void*>a, <void*>b, <void*> c)
  * 
  * cdef inline object PyArray_MultiIterNew4(a, b, c, d):             # <<<<<<<<<<<<<<
@@ -34815,7 +34815,7 @@ static CYTHON_INLINE PyObject *__pyx_f_5numpy_PyArray_MultiIterNew4(PyObject *__
   PyObject *__pyx_t_1 = NULL;
   __Pyx_RefNannySetupContext("PyArray_MultiIterNew4", 0);
 
-  /* ".tox/py37/lib/python3.7/site-packages/Cython/Includes/numpy/__init__.pxd":831
+  /* "../../../pyenv/scikit-allel-py37/lib/python3.7/site-packages/Cython/Includes/numpy/__init__.pxd":831
  * 
  * cdef inline object PyArray_MultiIterNew4(a, b, c, d):
  *     return PyArray_MultiIterNew(4, <void*>a, <void*>b, <void*>c, <void*> d)             # <<<<<<<<<<<<<<
@@ -34829,7 +34829,7 @@ static CYTHON_INLINE PyObject *__pyx_f_5numpy_PyArray_MultiIterNew4(PyObject *__
   __pyx_t_1 = 0;
   goto __pyx_L0;
 
-  /* ".tox/py37/lib/python3.7/site-packages/Cython/Includes/numpy/__init__.pxd":830
+  /* "../../../pyenv/scikit-allel-py37/lib/python3.7/site-packages/Cython/Includes/numpy/__init__.pxd":830
  *     return PyArray_MultiIterNew(3, <void*>a, <void*>b, <void*> c)
  * 
  * cdef inline object PyArray_MultiIterNew4(a, b, c, d):             # <<<<<<<<<<<<<<
@@ -34848,7 +34848,7 @@ static CYTHON_INLINE PyObject *__pyx_f_5numpy_PyArray_MultiIterNew4(PyObject *__
   return __pyx_r;
 }
 
-/* ".tox/py37/lib/python3.7/site-packages/Cython/Includes/numpy/__init__.pxd":833
+/* "../../../pyenv/scikit-allel-py37/lib/python3.7/site-packages/Cython/Includes/numpy/__init__.pxd":833
  *     return PyArray_MultiIterNew(4, <void*>a, <void*>b, <void*>c, <void*> d)
  * 
  * cdef inline object PyArray_MultiIterNew5(a, b, c, d, e):             # <<<<<<<<<<<<<<
@@ -34862,7 +34862,7 @@ static CYTHON_INLINE PyObject *__pyx_f_5numpy_PyArray_MultiIterNew5(PyObject *__
   PyObject *__pyx_t_1 = NULL;
   __Pyx_RefNannySetupContext("PyArray_MultiIterNew5", 0);
 
-  /* ".tox/py37/lib/python3.7/site-packages/Cython/Includes/numpy/__init__.pxd":834
+  /* "../../../pyenv/scikit-allel-py37/lib/python3.7/site-packages/Cython/Includes/numpy/__init__.pxd":834
  * 
  * cdef inline object PyArray_MultiIterNew5(a, b, c, d, e):
  *     return PyArray_MultiIterNew(5, <void*>a, <void*>b, <void*>c, <void*> d, <void*> e)             # <<<<<<<<<<<<<<
@@ -34876,7 +34876,7 @@ static CYTHON_INLINE PyObject *__pyx_f_5numpy_PyArray_MultiIterNew5(PyObject *__
   __pyx_t_1 = 0;
   goto __pyx_L0;
 
-  /* ".tox/py37/lib/python3.7/site-packages/Cython/Includes/numpy/__init__.pxd":833
+  /* "../../../pyenv/scikit-allel-py37/lib/python3.7/site-packages/Cython/Includes/numpy/__init__.pxd":833
  *     return PyArray_MultiIterNew(4, <void*>a, <void*>b, <void*>c, <void*> d)
  * 
  * cdef inline object PyArray_MultiIterNew5(a, b, c, d, e):             # <<<<<<<<<<<<<<
@@ -34895,7 +34895,7 @@ static CYTHON_INLINE PyObject *__pyx_f_5numpy_PyArray_MultiIterNew5(PyObject *__
   return __pyx_r;
 }
 
-/* ".tox/py37/lib/python3.7/site-packages/Cython/Includes/numpy/__init__.pxd":836
+/* "../../../pyenv/scikit-allel-py37/lib/python3.7/site-packages/Cython/Includes/numpy/__init__.pxd":836
  *     return PyArray_MultiIterNew(5, <void*>a, <void*>b, <void*>c, <void*> d, <void*> e)
  * 
  * cdef inline tuple PyDataType_SHAPE(dtype d):             # <<<<<<<<<<<<<<
@@ -34909,7 +34909,7 @@ static CYTHON_INLINE PyObject *__pyx_f_5numpy_PyDataType_SHAPE(PyArray_Descr *__
   int __pyx_t_1;
   __Pyx_RefNannySetupContext("PyDataType_SHAPE", 0);
 
-  /* ".tox/py37/lib/python3.7/site-packages/Cython/Includes/numpy/__init__.pxd":837
+  /* "../../../pyenv/scikit-allel-py37/lib/python3.7/site-packages/Cython/Includes/numpy/__init__.pxd":837
  * 
  * cdef inline tuple PyDataType_SHAPE(dtype d):
  *     if PyDataType_HASSUBARRAY(d):             # <<<<<<<<<<<<<<
@@ -34919,7 +34919,7 @@ static CYTHON_INLINE PyObject *__pyx_f_5numpy_PyDataType_SHAPE(PyArray_Descr *__
   __pyx_t_1 = (PyDataType_HASSUBARRAY(__pyx_v_d) != 0);
   if (__pyx_t_1) {
 
-    /* ".tox/py37/lib/python3.7/site-packages/Cython/Includes/numpy/__init__.pxd":838
+    /* "../../../pyenv/scikit-allel-py37/lib/python3.7/site-packages/Cython/Includes/numpy/__init__.pxd":838
  * cdef inline tuple PyDataType_SHAPE(dtype d):
  *     if PyDataType_HASSUBARRAY(d):
  *         return <tuple>d.subarray.shape             # <<<<<<<<<<<<<<
@@ -34931,7 +34931,7 @@ static CYTHON_INLINE PyObject *__pyx_f_5numpy_PyDataType_SHAPE(PyArray_Descr *__
     __pyx_r = ((PyObject*)__pyx_v_d->subarray->shape);
     goto __pyx_L0;
 
-    /* ".tox/py37/lib/python3.7/site-packages/Cython/Includes/numpy/__init__.pxd":837
+    /* "../../../pyenv/scikit-allel-py37/lib/python3.7/site-packages/Cython/Includes/numpy/__init__.pxd":837
  * 
  * cdef inline tuple PyDataType_SHAPE(dtype d):
  *     if PyDataType_HASSUBARRAY(d):             # <<<<<<<<<<<<<<
@@ -34940,7 +34940,7 @@ static CYTHON_INLINE PyObject *__pyx_f_5numpy_PyDataType_SHAPE(PyArray_Descr *__
  */
   }
 
-  /* ".tox/py37/lib/python3.7/site-packages/Cython/Includes/numpy/__init__.pxd":840
+  /* "../../../pyenv/scikit-allel-py37/lib/python3.7/site-packages/Cython/Includes/numpy/__init__.pxd":840
  *         return <tuple>d.subarray.shape
  *     else:
  *         return ()             # <<<<<<<<<<<<<<
@@ -34954,7 +34954,7 @@ static CYTHON_INLINE PyObject *__pyx_f_5numpy_PyDataType_SHAPE(PyArray_Descr *__
     goto __pyx_L0;
   }
 
-  /* ".tox/py37/lib/python3.7/site-packages/Cython/Includes/numpy/__init__.pxd":836
+  /* "../../../pyenv/scikit-allel-py37/lib/python3.7/site-packages/Cython/Includes/numpy/__init__.pxd":836
  *     return PyArray_MultiIterNew(5, <void*>a, <void*>b, <void*>c, <void*> d, <void*> e)
  * 
  * cdef inline tuple PyDataType_SHAPE(dtype d):             # <<<<<<<<<<<<<<
@@ -34969,7 +34969,7 @@ static CYTHON_INLINE PyObject *__pyx_f_5numpy_PyDataType_SHAPE(PyArray_Descr *__
   return __pyx_r;
 }
 
-/* ".tox/py37/lib/python3.7/site-packages/Cython/Includes/numpy/__init__.pxd":842
+/* "../../../pyenv/scikit-allel-py37/lib/python3.7/site-packages/Cython/Includes/numpy/__init__.pxd":842
  *         return ()
  * 
  * cdef inline char* _util_dtypestring(dtype descr, char* f, char* end, int* offset) except NULL:             # <<<<<<<<<<<<<<
@@ -34998,7 +34998,7 @@ static CYTHON_INLINE char *__pyx_f_5numpy__util_dtypestring(PyArray_Descr *__pyx
   char *__pyx_t_9;
   __Pyx_RefNannySetupContext("_util_dtypestring", 0);
 
-  /* ".tox/py37/lib/python3.7/site-packages/Cython/Includes/numpy/__init__.pxd":847
+  /* "../../../pyenv/scikit-allel-py37/lib/python3.7/site-packages/Cython/Includes/numpy/__init__.pxd":847
  * 
  *     cdef dtype child
  *     cdef int endian_detector = 1             # <<<<<<<<<<<<<<
@@ -35007,7 +35007,7 @@ static CYTHON_INLINE char *__pyx_f_5numpy__util_dtypestring(PyArray_Descr *__pyx
  */
   __pyx_v_endian_detector = 1;
 
-  /* ".tox/py37/lib/python3.7/site-packages/Cython/Includes/numpy/__init__.pxd":848
+  /* "../../../pyenv/scikit-allel-py37/lib/python3.7/site-packages/Cython/Includes/numpy/__init__.pxd":848
  *     cdef dtype child
  *     cdef int endian_detector = 1
  *     cdef bint little_endian = ((<char*>&endian_detector)[0] != 0)             # <<<<<<<<<<<<<<
@@ -35016,7 +35016,7 @@ static CYTHON_INLINE char *__pyx_f_5numpy__util_dtypestring(PyArray_Descr *__pyx
  */
   __pyx_v_little_endian = ((((char *)(&__pyx_v_endian_detector))[0]) != 0);
 
-  /* ".tox/py37/lib/python3.7/site-packages/Cython/Includes/numpy/__init__.pxd":851
+  /* "../../../pyenv/scikit-allel-py37/lib/python3.7/site-packages/Cython/Includes/numpy/__init__.pxd":851
  *     cdef tuple fields
  * 
  *     for childname in descr.names:             # <<<<<<<<<<<<<<
@@ -35039,7 +35039,7 @@ static CYTHON_INLINE char *__pyx_f_5numpy__util_dtypestring(PyArray_Descr *__pyx
     __Pyx_XDECREF_SET(__pyx_v_childname, __pyx_t_3);
     __pyx_t_3 = 0;
 
-    /* ".tox/py37/lib/python3.7/site-packages/Cython/Includes/numpy/__init__.pxd":852
+    /* "../../../pyenv/scikit-allel-py37/lib/python3.7/site-packages/Cython/Includes/numpy/__init__.pxd":852
  * 
  *     for childname in descr.names:
  *         fields = descr.fields[childname]             # <<<<<<<<<<<<<<
@@ -35056,7 +35056,7 @@ static CYTHON_INLINE char *__pyx_f_5numpy__util_dtypestring(PyArray_Descr *__pyx
     __Pyx_XDECREF_SET(__pyx_v_fields, ((PyObject*)__pyx_t_3));
     __pyx_t_3 = 0;
 
-    /* ".tox/py37/lib/python3.7/site-packages/Cython/Includes/numpy/__init__.pxd":853
+    /* "../../../pyenv/scikit-allel-py37/lib/python3.7/site-packages/Cython/Includes/numpy/__init__.pxd":853
  *     for childname in descr.names:
  *         fields = descr.fields[childname]
  *         child, new_offset = fields             # <<<<<<<<<<<<<<
@@ -35091,7 +35091,7 @@ static CYTHON_INLINE char *__pyx_f_5numpy__util_dtypestring(PyArray_Descr *__pyx
     __Pyx_XDECREF_SET(__pyx_v_new_offset, __pyx_t_4);
     __pyx_t_4 = 0;
 
-    /* ".tox/py37/lib/python3.7/site-packages/Cython/Includes/numpy/__init__.pxd":855
+    /* "../../../pyenv/scikit-allel-py37/lib/python3.7/site-packages/Cython/Includes/numpy/__init__.pxd":855
  *         child, new_offset = fields
  * 
  *         if (end - f) - <int>(new_offset - offset[0]) < 15:             # <<<<<<<<<<<<<<
@@ -35108,7 +35108,7 @@ static CYTHON_INLINE char *__pyx_f_5numpy__util_dtypestring(PyArray_Descr *__pyx
     __pyx_t_6 = ((((__pyx_v_end - __pyx_v_f) - ((int)__pyx_t_5)) < 15) != 0);
     if (unlikely(__pyx_t_6)) {
 
-      /* ".tox/py37/lib/python3.7/site-packages/Cython/Includes/numpy/__init__.pxd":856
+      /* "../../../pyenv/scikit-allel-py37/lib/python3.7/site-packages/Cython/Includes/numpy/__init__.pxd":856
  * 
  *         if (end - f) - <int>(new_offset - offset[0]) < 15:
  *             raise RuntimeError(u"Format string allocated too short, see comment in numpy.pxd")             # <<<<<<<<<<<<<<
@@ -35121,7 +35121,7 @@ static CYTHON_INLINE char *__pyx_f_5numpy__util_dtypestring(PyArray_Descr *__pyx
       __Pyx_DECREF(__pyx_t_3); __pyx_t_3 = 0;
       __PYX_ERR(1, 856, __pyx_L1_error)
 
-      /* ".tox/py37/lib/python3.7/site-packages/Cython/Includes/numpy/__init__.pxd":855
+      /* "../../../pyenv/scikit-allel-py37/lib/python3.7/site-packages/Cython/Includes/numpy/__init__.pxd":855
  *         child, new_offset = fields
  * 
  *         if (end - f) - <int>(new_offset - offset[0]) < 15:             # <<<<<<<<<<<<<<
@@ -35130,7 +35130,7 @@ static CYTHON_INLINE char *__pyx_f_5numpy__util_dtypestring(PyArray_Descr *__pyx
  */
     }
 
-    /* ".tox/py37/lib/python3.7/site-packages/Cython/Includes/numpy/__init__.pxd":858
+    /* "../../../pyenv/scikit-allel-py37/lib/python3.7/site-packages/Cython/Includes/numpy/__init__.pxd":858
  *             raise RuntimeError(u"Format string allocated too short, see comment in numpy.pxd")
  * 
  *         if ((child.byteorder == c'>' and little_endian) or             # <<<<<<<<<<<<<<
@@ -35150,7 +35150,7 @@ static CYTHON_INLINE char *__pyx_f_5numpy__util_dtypestring(PyArray_Descr *__pyx
     }
     __pyx_L8_next_or:;
 
-    /* ".tox/py37/lib/python3.7/site-packages/Cython/Includes/numpy/__init__.pxd":859
+    /* "../../../pyenv/scikit-allel-py37/lib/python3.7/site-packages/Cython/Includes/numpy/__init__.pxd":859
  * 
  *         if ((child.byteorder == c'>' and little_endian) or
  *             (child.byteorder == c'<' and not little_endian)):             # <<<<<<<<<<<<<<
@@ -35167,7 +35167,7 @@ static CYTHON_INLINE char *__pyx_f_5numpy__util_dtypestring(PyArray_Descr *__pyx
     __pyx_t_6 = __pyx_t_7;
     __pyx_L7_bool_binop_done:;
 
-    /* ".tox/py37/lib/python3.7/site-packages/Cython/Includes/numpy/__init__.pxd":858
+    /* "../../../pyenv/scikit-allel-py37/lib/python3.7/site-packages/Cython/Includes/numpy/__init__.pxd":858
  *             raise RuntimeError(u"Format string allocated too short, see comment in numpy.pxd")
  * 
  *         if ((child.byteorder == c'>' and little_endian) or             # <<<<<<<<<<<<<<
@@ -35176,7 +35176,7 @@ static CYTHON_INLINE char *__pyx_f_5numpy__util_dtypestring(PyArray_Descr *__pyx
  */
     if (unlikely(__pyx_t_6)) {
 
-      /* ".tox/py37/lib/python3.7/site-packages/Cython/Includes/numpy/__init__.pxd":860
+      /* "../../../pyenv/scikit-allel-py37/lib/python3.7/site-packages/Cython/Includes/numpy/__init__.pxd":860
  *         if ((child.byteorder == c'>' and little_endian) or
  *             (child.byteorder == c'<' and not little_endian)):
  *             raise ValueError(u"Non-native byte order not supported")             # <<<<<<<<<<<<<<
@@ -35189,7 +35189,7 @@ static CYTHON_INLINE char *__pyx_f_5numpy__util_dtypestring(PyArray_Descr *__pyx
       __Pyx_DECREF(__pyx_t_3); __pyx_t_3 = 0;
       __PYX_ERR(1, 860, __pyx_L1_error)
 
-      /* ".tox/py37/lib/python3.7/site-packages/Cython/Includes/numpy/__init__.pxd":858
+      /* "../../../pyenv/scikit-allel-py37/lib/python3.7/site-packages/Cython/Includes/numpy/__init__.pxd":858
  *             raise RuntimeError(u"Format string allocated too short, see comment in numpy.pxd")
  * 
  *         if ((child.byteorder == c'>' and little_endian) or             # <<<<<<<<<<<<<<
@@ -35198,7 +35198,7 @@ static CYTHON_INLINE char *__pyx_f_5numpy__util_dtypestring(PyArray_Descr *__pyx
  */
     }
 
-    /* ".tox/py37/lib/python3.7/site-packages/Cython/Includes/numpy/__init__.pxd":870
+    /* "../../../pyenv/scikit-allel-py37/lib/python3.7/site-packages/Cython/Includes/numpy/__init__.pxd":870
  * 
  *         # Output padding bytes
  *         while offset[0] < new_offset:             # <<<<<<<<<<<<<<
@@ -35214,7 +35214,7 @@ static CYTHON_INLINE char *__pyx_f_5numpy__util_dtypestring(PyArray_Descr *__pyx
       __Pyx_DECREF(__pyx_t_4); __pyx_t_4 = 0;
       if (!__pyx_t_6) break;
 
-      /* ".tox/py37/lib/python3.7/site-packages/Cython/Includes/numpy/__init__.pxd":871
+      /* "../../../pyenv/scikit-allel-py37/lib/python3.7/site-packages/Cython/Includes/numpy/__init__.pxd":871
  *         # Output padding bytes
  *         while offset[0] < new_offset:
  *             f[0] = 120 # "x"; pad byte             # <<<<<<<<<<<<<<
@@ -35223,7 +35223,7 @@ static CYTHON_INLINE char *__pyx_f_5numpy__util_dtypestring(PyArray_Descr *__pyx
  */
       (__pyx_v_f[0]) = 0x78;
 
-      /* ".tox/py37/lib/python3.7/site-packages/Cython/Includes/numpy/__init__.pxd":872
+      /* "../../../pyenv/scikit-allel-py37/lib/python3.7/site-packages/Cython/Includes/numpy/__init__.pxd":872
  *         while offset[0] < new_offset:
  *             f[0] = 120 # "x"; pad byte
  *             f += 1             # <<<<<<<<<<<<<<
@@ -35232,7 +35232,7 @@ static CYTHON_INLINE char *__pyx_f_5numpy__util_dtypestring(PyArray_Descr *__pyx
  */
       __pyx_v_f = (__pyx_v_f + 1);
 
-      /* ".tox/py37/lib/python3.7/site-packages/Cython/Includes/numpy/__init__.pxd":873
+      /* "../../../pyenv/scikit-allel-py37/lib/python3.7/site-packages/Cython/Includes/numpy/__init__.pxd":873
  *             f[0] = 120 # "x"; pad byte
  *             f += 1
  *             offset[0] += 1             # <<<<<<<<<<<<<<
@@ -35243,7 +35243,7 @@ static CYTHON_INLINE char *__pyx_f_5numpy__util_dtypestring(PyArray_Descr *__pyx
       (__pyx_v_offset[__pyx_t_8]) = ((__pyx_v_offset[__pyx_t_8]) + 1);
     }
 
-    /* ".tox/py37/lib/python3.7/site-packages/Cython/Includes/numpy/__init__.pxd":875
+    /* "../../../pyenv/scikit-allel-py37/lib/python3.7/site-packages/Cython/Includes/numpy/__init__.pxd":875
  *             offset[0] += 1
  * 
  *         offset[0] += child.itemsize             # <<<<<<<<<<<<<<
@@ -35253,7 +35253,7 @@ static CYTHON_INLINE char *__pyx_f_5numpy__util_dtypestring(PyArray_Descr *__pyx
     __pyx_t_8 = 0;
     (__pyx_v_offset[__pyx_t_8]) = ((__pyx_v_offset[__pyx_t_8]) + __pyx_v_child->elsize);
 
-    /* ".tox/py37/lib/python3.7/site-packages/Cython/Includes/numpy/__init__.pxd":877
+    /* "../../../pyenv/scikit-allel-py37/lib/python3.7/site-packages/Cython/Includes/numpy/__init__.pxd":877
  *         offset[0] += child.itemsize
  * 
  *         if not PyDataType_HASFIELDS(child):             # <<<<<<<<<<<<<<
@@ -35263,7 +35263,7 @@ static CYTHON_INLINE char *__pyx_f_5numpy__util_dtypestring(PyArray_Descr *__pyx
     __pyx_t_6 = ((!(PyDataType_HASFIELDS(__pyx_v_child) != 0)) != 0);
     if (__pyx_t_6) {
 
-      /* ".tox/py37/lib/python3.7/site-packages/Cython/Includes/numpy/__init__.pxd":878
+      /* "../../../pyenv/scikit-allel-py37/lib/python3.7/site-packages/Cython/Includes/numpy/__init__.pxd":878
  * 
  *         if not PyDataType_HASFIELDS(child):
  *             t = child.type_num             # <<<<<<<<<<<<<<
@@ -35275,7 +35275,7 @@ static CYTHON_INLINE char *__pyx_f_5numpy__util_dtypestring(PyArray_Descr *__pyx
       __Pyx_XDECREF_SET(__pyx_v_t, __pyx_t_4);
       __pyx_t_4 = 0;
 
-      /* ".tox/py37/lib/python3.7/site-packages/Cython/Includes/numpy/__init__.pxd":879
+      /* "../../../pyenv/scikit-allel-py37/lib/python3.7/site-packages/Cython/Includes/numpy/__init__.pxd":879
  *         if not PyDataType_HASFIELDS(child):
  *             t = child.type_num
  *             if end - f < 5:             # <<<<<<<<<<<<<<
@@ -35285,7 +35285,7 @@ static CYTHON_INLINE char *__pyx_f_5numpy__util_dtypestring(PyArray_Descr *__pyx
       __pyx_t_6 = (((__pyx_v_end - __pyx_v_f) < 5) != 0);
       if (unlikely(__pyx_t_6)) {
 
-        /* ".tox/py37/lib/python3.7/site-packages/Cython/Includes/numpy/__init__.pxd":880
+        /* "../../../pyenv/scikit-allel-py37/lib/python3.7/site-packages/Cython/Includes/numpy/__init__.pxd":880
  *             t = child.type_num
  *             if end - f < 5:
  *                 raise RuntimeError(u"Format string allocated too short.")             # <<<<<<<<<<<<<<
@@ -35298,7 +35298,7 @@ static CYTHON_INLINE char *__pyx_f_5numpy__util_dtypestring(PyArray_Descr *__pyx
         __Pyx_DECREF(__pyx_t_4); __pyx_t_4 = 0;
         __PYX_ERR(1, 880, __pyx_L1_error)
 
-        /* ".tox/py37/lib/python3.7/site-packages/Cython/Includes/numpy/__init__.pxd":879
+        /* "../../../pyenv/scikit-allel-py37/lib/python3.7/site-packages/Cython/Includes/numpy/__init__.pxd":879
  *         if not PyDataType_HASFIELDS(child):
  *             t = child.type_num
  *             if end - f < 5:             # <<<<<<<<<<<<<<
@@ -35307,7 +35307,7 @@ static CYTHON_INLINE char *__pyx_f_5numpy__util_dtypestring(PyArray_Descr *__pyx
  */
       }
 
-      /* ".tox/py37/lib/python3.7/site-packages/Cython/Includes/numpy/__init__.pxd":883
+      /* "../../../pyenv/scikit-allel-py37/lib/python3.7/site-packages/Cython/Includes/numpy/__init__.pxd":883
  * 
  *             # Until ticket #99 is fixed, use integers to avoid warnings
  *             if   t == NPY_BYTE:        f[0] =  98 #"b"             # <<<<<<<<<<<<<<
@@ -35325,7 +35325,7 @@ static CYTHON_INLINE char *__pyx_f_5numpy__util_dtypestring(PyArray_Descr *__pyx
         goto __pyx_L15;
       }
 
-      /* ".tox/py37/lib/python3.7/site-packages/Cython/Includes/numpy/__init__.pxd":884
+      /* "../../../pyenv/scikit-allel-py37/lib/python3.7/site-packages/Cython/Includes/numpy/__init__.pxd":884
  *             # Until ticket #99 is fixed, use integers to avoid warnings
  *             if   t == NPY_BYTE:        f[0] =  98 #"b"
  *             elif t == NPY_UBYTE:       f[0] =  66 #"B"             # <<<<<<<<<<<<<<
@@ -35343,7 +35343,7 @@ static CYTHON_INLINE char *__pyx_f_5numpy__util_dtypestring(PyArray_Descr *__pyx
         goto __pyx_L15;
       }
 
-      /* ".tox/py37/lib/python3.7/site-packages/Cython/Includes/numpy/__init__.pxd":885
+      /* "../../../pyenv/scikit-allel-py37/lib/python3.7/site-packages/Cython/Includes/numpy/__init__.pxd":885
  *             if   t == NPY_BYTE:        f[0] =  98 #"b"
  *             elif t == NPY_UBYTE:       f[0] =  66 #"B"
  *             elif t == NPY_SHORT:       f[0] = 104 #"h"             # <<<<<<<<<<<<<<
@@ -35361,7 +35361,7 @@ static CYTHON_INLINE char *__pyx_f_5numpy__util_dtypestring(PyArray_Descr *__pyx
         goto __pyx_L15;
       }
 
-      /* ".tox/py37/lib/python3.7/site-packages/Cython/Includes/numpy/__init__.pxd":886
+      /* "../../../pyenv/scikit-allel-py37/lib/python3.7/site-packages/Cython/Includes/numpy/__init__.pxd":886
  *             elif t == NPY_UBYTE:       f[0] =  66 #"B"
  *             elif t == NPY_SHORT:       f[0] = 104 #"h"
  *             elif t == NPY_USHORT:      f[0] =  72 #"H"             # <<<<<<<<<<<<<<
@@ -35379,7 +35379,7 @@ static CYTHON_INLINE char *__pyx_f_5numpy__util_dtypestring(PyArray_Descr *__pyx
         goto __pyx_L15;
       }
 
-      /* ".tox/py37/lib/python3.7/site-packages/Cython/Includes/numpy/__init__.pxd":887
+      /* "../../../pyenv/scikit-allel-py37/lib/python3.7/site-packages/Cython/Includes/numpy/__init__.pxd":887
  *             elif t == NPY_SHORT:       f[0] = 104 #"h"
  *             elif t == NPY_USHORT:      f[0] =  72 #"H"
  *             elif t == NPY_INT:         f[0] = 105 #"i"             # <<<<<<<<<<<<<<
@@ -35397,7 +35397,7 @@ static CYTHON_INLINE char *__pyx_f_5numpy__util_dtypestring(PyArray_Descr *__pyx
         goto __pyx_L15;
       }
 
-      /* ".tox/py37/lib/python3.7/site-packages/Cython/Includes/numpy/__init__.pxd":888
+      /* "../../../pyenv/scikit-allel-py37/lib/python3.7/site-packages/Cython/Includes/numpy/__init__.pxd":888
  *             elif t == NPY_USHORT:      f[0] =  72 #"H"
  *             elif t == NPY_INT:         f[0] = 105 #"i"
  *             elif t == NPY_UINT:        f[0] =  73 #"I"             # <<<<<<<<<<<<<<
@@ -35415,7 +35415,7 @@ static CYTHON_INLINE char *__pyx_f_5numpy__util_dtypestring(PyArray_Descr *__pyx
         goto __pyx_L15;
       }
 
-      /* ".tox/py37/lib/python3.7/site-packages/Cython/Includes/numpy/__init__.pxd":889
+      /* "../../../pyenv/scikit-allel-py37/lib/python3.7/site-packages/Cython/Includes/numpy/__init__.pxd":889
  *             elif t == NPY_INT:         f[0] = 105 #"i"
  *             elif t == NPY_UINT:        f[0] =  73 #"I"
  *             elif t == NPY_LONG:        f[0] = 108 #"l"             # <<<<<<<<<<<<<<
@@ -35433,7 +35433,7 @@ static CYTHON_INLINE char *__pyx_f_5numpy__util_dtypestring(PyArray_Descr *__pyx
         goto __pyx_L15;
       }
 
-      /* ".tox/py37/lib/python3.7/site-packages/Cython/Includes/numpy/__init__.pxd":890
+      /* "../../../pyenv/scikit-allel-py37/lib/python3.7/site-packages/Cython/Includes/numpy/__init__.pxd":890
  *             elif t == NPY_UINT:        f[0] =  73 #"I"
  *             elif t == NPY_LONG:        f[0] = 108 #"l"
  *             elif t == NPY_ULONG:       f[0] = 76  #"L"             # <<<<<<<<<<<<<<
@@ -35451,7 +35451,7 @@ static CYTHON_INLINE char *__pyx_f_5numpy__util_dtypestring(PyArray_Descr *__pyx
         goto __pyx_L15;
       }
 
-      /* ".tox/py37/lib/python3.7/site-packages/Cython/Includes/numpy/__init__.pxd":891
+      /* "../../../pyenv/scikit-allel-py37/lib/python3.7/site-packages/Cython/Includes/numpy/__init__.pxd":891
  *             elif t == NPY_LONG:        f[0] = 108 #"l"
  *             elif t == NPY_ULONG:       f[0] = 76  #"L"
  *             elif t == NPY_LONGLONG:    f[0] = 113 #"q"             # <<<<<<<<<<<<<<
@@ -35469,7 +35469,7 @@ static CYTHON_INLINE char *__pyx_f_5numpy__util_dtypestring(PyArray_Descr *__pyx
         goto __pyx_L15;
       }
 
-      /* ".tox/py37/lib/python3.7/site-packages/Cython/Includes/numpy/__init__.pxd":892
+      /* "../../../pyenv/scikit-allel-py37/lib/python3.7/site-packages/Cython/Includes/numpy/__init__.pxd":892
  *             elif t == NPY_ULONG:       f[0] = 76  #"L"
  *             elif t == NPY_LONGLONG:    f[0] = 113 #"q"
  *             elif t == NPY_ULONGLONG:   f[0] = 81  #"Q"             # <<<<<<<<<<<<<<
@@ -35487,7 +35487,7 @@ static CYTHON_INLINE char *__pyx_f_5numpy__util_dtypestring(PyArray_Descr *__pyx
         goto __pyx_L15;
       }
 
-      /* ".tox/py37/lib/python3.7/site-packages/Cython/Includes/numpy/__init__.pxd":893
+      /* "../../../pyenv/scikit-allel-py37/lib/python3.7/site-packages/Cython/Includes/numpy/__init__.pxd":893
  *             elif t == NPY_LONGLONG:    f[0] = 113 #"q"
  *             elif t == NPY_ULONGLONG:   f[0] = 81  #"Q"
  *             elif t == NPY_FLOAT:       f[0] = 102 #"f"             # <<<<<<<<<<<<<<
@@ -35505,7 +35505,7 @@ static CYTHON_INLINE char *__pyx_f_5numpy__util_dtypestring(PyArray_Descr *__pyx
         goto __pyx_L15;
       }
 
-      /* ".tox/py37/lib/python3.7/site-packages/Cython/Includes/numpy/__init__.pxd":894
+      /* "../../../pyenv/scikit-allel-py37/lib/python3.7/site-packages/Cython/Includes/numpy/__init__.pxd":894
  *             elif t == NPY_ULONGLONG:   f[0] = 81  #"Q"
  *             elif t == NPY_FLOAT:       f[0] = 102 #"f"
  *             elif t == NPY_DOUBLE:      f[0] = 100 #"d"             # <<<<<<<<<<<<<<
@@ -35523,7 +35523,7 @@ static CYTHON_INLINE char *__pyx_f_5numpy__util_dtypestring(PyArray_Descr *__pyx
         goto __pyx_L15;
       }
 
-      /* ".tox/py37/lib/python3.7/site-packages/Cython/Includes/numpy/__init__.pxd":895
+      /* "../../../pyenv/scikit-allel-py37/lib/python3.7/site-packages/Cython/Includes/numpy/__init__.pxd":895
  *             elif t == NPY_FLOAT:       f[0] = 102 #"f"
  *             elif t == NPY_DOUBLE:      f[0] = 100 #"d"
  *             elif t == NPY_LONGDOUBLE:  f[0] = 103 #"g"             # <<<<<<<<<<<<<<
@@ -35541,7 +35541,7 @@ static CYTHON_INLINE char *__pyx_f_5numpy__util_dtypestring(PyArray_Descr *__pyx
         goto __pyx_L15;
       }
 
-      /* ".tox/py37/lib/python3.7/site-packages/Cython/Includes/numpy/__init__.pxd":896
+      /* "../../../pyenv/scikit-allel-py37/lib/python3.7/site-packages/Cython/Includes/numpy/__init__.pxd":896
  *             elif t == NPY_DOUBLE:      f[0] = 100 #"d"
  *             elif t == NPY_LONGDOUBLE:  f[0] = 103 #"g"
  *             elif t == NPY_CFLOAT:      f[0] = 90; f[1] = 102; f += 1 # Zf             # <<<<<<<<<<<<<<
@@ -35561,7 +35561,7 @@ static CYTHON_INLINE char *__pyx_f_5numpy__util_dtypestring(PyArray_Descr *__pyx
         goto __pyx_L15;
       }
 
-      /* ".tox/py37/lib/python3.7/site-packages/Cython/Includes/numpy/__init__.pxd":897
+      /* "../../../pyenv/scikit-allel-py37/lib/python3.7/site-packages/Cython/Includes/numpy/__init__.pxd":897
  *             elif t == NPY_LONGDOUBLE:  f[0] = 103 #"g"
  *             elif t == NPY_CFLOAT:      f[0] = 90; f[1] = 102; f += 1 # Zf
  *             elif t == NPY_CDOUBLE:     f[0] = 90; f[1] = 100; f += 1 # Zd             # <<<<<<<<<<<<<<
@@ -35581,7 +35581,7 @@ static CYTHON_INLINE char *__pyx_f_5numpy__util_dtypestring(PyArray_Descr *__pyx
         goto __pyx_L15;
       }
 
-      /* ".tox/py37/lib/python3.7/site-packages/Cython/Includes/numpy/__init__.pxd":898
+      /* "../../../pyenv/scikit-allel-py37/lib/python3.7/site-packages/Cython/Includes/numpy/__init__.pxd":898
  *             elif t == NPY_CFLOAT:      f[0] = 90; f[1] = 102; f += 1 # Zf
  *             elif t == NPY_CDOUBLE:     f[0] = 90; f[1] = 100; f += 1 # Zd
  *             elif t == NPY_CLONGDOUBLE: f[0] = 90; f[1] = 103; f += 1 # Zg             # <<<<<<<<<<<<<<
@@ -35601,7 +35601,7 @@ static CYTHON_INLINE char *__pyx_f_5numpy__util_dtypestring(PyArray_Descr *__pyx
         goto __pyx_L15;
       }
 
-      /* ".tox/py37/lib/python3.7/site-packages/Cython/Includes/numpy/__init__.pxd":899
+      /* "../../../pyenv/scikit-allel-py37/lib/python3.7/site-packages/Cython/Includes/numpy/__init__.pxd":899
  *             elif t == NPY_CDOUBLE:     f[0] = 90; f[1] = 100; f += 1 # Zd
  *             elif t == NPY_CLONGDOUBLE: f[0] = 90; f[1] = 103; f += 1 # Zg
  *             elif t == NPY_OBJECT:      f[0] = 79 #"O"             # <<<<<<<<<<<<<<
@@ -35619,7 +35619,7 @@ static CYTHON_INLINE char *__pyx_f_5numpy__util_dtypestring(PyArray_Descr *__pyx
         goto __pyx_L15;
       }
 
-      /* ".tox/py37/lib/python3.7/site-packages/Cython/Includes/numpy/__init__.pxd":901
+      /* "../../../pyenv/scikit-allel-py37/lib/python3.7/site-packages/Cython/Includes/numpy/__init__.pxd":901
  *             elif t == NPY_OBJECT:      f[0] = 79 #"O"
  *             else:
  *                 raise ValueError(u"unknown dtype code in numpy.pxd (%d)" % t)             # <<<<<<<<<<<<<<
@@ -35638,7 +35638,7 @@ static CYTHON_INLINE char *__pyx_f_5numpy__util_dtypestring(PyArray_Descr *__pyx
       }
       __pyx_L15:;
 
-      /* ".tox/py37/lib/python3.7/site-packages/Cython/Includes/numpy/__init__.pxd":902
+      /* "../../../pyenv/scikit-allel-py37/lib/python3.7/site-packages/Cython/Includes/numpy/__init__.pxd":902
  *             else:
  *                 raise ValueError(u"unknown dtype code in numpy.pxd (%d)" % t)
  *             f += 1             # <<<<<<<<<<<<<<
@@ -35647,7 +35647,7 @@ static CYTHON_INLINE char *__pyx_f_5numpy__util_dtypestring(PyArray_Descr *__pyx
  */
       __pyx_v_f = (__pyx_v_f + 1);
 
-      /* ".tox/py37/lib/python3.7/site-packages/Cython/Includes/numpy/__init__.pxd":877
+      /* "../../../pyenv/scikit-allel-py37/lib/python3.7/site-packages/Cython/Includes/numpy/__init__.pxd":877
  *         offset[0] += child.itemsize
  * 
  *         if not PyDataType_HASFIELDS(child):             # <<<<<<<<<<<<<<
@@ -35657,7 +35657,7 @@ static CYTHON_INLINE char *__pyx_f_5numpy__util_dtypestring(PyArray_Descr *__pyx
       goto __pyx_L13;
     }
 
-    /* ".tox/py37/lib/python3.7/site-packages/Cython/Includes/numpy/__init__.pxd":906
+    /* "../../../pyenv/scikit-allel-py37/lib/python3.7/site-packages/Cython/Includes/numpy/__init__.pxd":906
  *             # Cython ignores struct boundary information ("T{...}"),
  *             # so don't output it
  *             f = _util_dtypestring(child, f, end, offset)             # <<<<<<<<<<<<<<
@@ -35670,7 +35670,7 @@ static CYTHON_INLINE char *__pyx_f_5numpy__util_dtypestring(PyArray_Descr *__pyx
     }
     __pyx_L13:;
 
-    /* ".tox/py37/lib/python3.7/site-packages/Cython/Includes/numpy/__init__.pxd":851
+    /* "../../../pyenv/scikit-allel-py37/lib/python3.7/site-packages/Cython/Includes/numpy/__init__.pxd":851
  *     cdef tuple fields
  * 
  *     for childname in descr.names:             # <<<<<<<<<<<<<<
@@ -35680,7 +35680,7 @@ static CYTHON_INLINE char *__pyx_f_5numpy__util_dtypestring(PyArray_Descr *__pyx
   }
   __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
 
-  /* ".tox/py37/lib/python3.7/site-packages/Cython/Includes/numpy/__init__.pxd":907
+  /* "../../../pyenv/scikit-allel-py37/lib/python3.7/site-packages/Cython/Includes/numpy/__init__.pxd":907
  *             # so don't output it
  *             f = _util_dtypestring(child, f, end, offset)
  *     return f             # <<<<<<<<<<<<<<
@@ -35690,7 +35690,7 @@ static CYTHON_INLINE char *__pyx_f_5numpy__util_dtypestring(PyArray_Descr *__pyx
   __pyx_r = __pyx_v_f;
   goto __pyx_L0;
 
-  /* ".tox/py37/lib/python3.7/site-packages/Cython/Includes/numpy/__init__.pxd":842
+  /* "../../../pyenv/scikit-allel-py37/lib/python3.7/site-packages/Cython/Includes/numpy/__init__.pxd":842
  *         return ()
  * 
  * cdef inline char* _util_dtypestring(dtype descr, char* f, char* end, int* offset) except NULL:             # <<<<<<<<<<<<<<
@@ -35715,7 +35715,7 @@ static CYTHON_INLINE char *__pyx_f_5numpy__util_dtypestring(PyArray_Descr *__pyx
   return __pyx_r;
 }
 
-/* ".tox/py37/lib/python3.7/site-packages/Cython/Includes/numpy/__init__.pxd":1022
+/* "../../../pyenv/scikit-allel-py37/lib/python3.7/site-packages/Cython/Includes/numpy/__init__.pxd":1022
  *     int _import_umath() except -1
  * 
  * cdef inline void set_array_base(ndarray arr, object base):             # <<<<<<<<<<<<<<
@@ -35727,7 +35727,7 @@ static CYTHON_INLINE void __pyx_f_5numpy_set_array_base(PyArrayObject *__pyx_v_a
   __Pyx_RefNannyDeclarations
   __Pyx_RefNannySetupContext("set_array_base", 0);
 
-  /* ".tox/py37/lib/python3.7/site-packages/Cython/Includes/numpy/__init__.pxd":1023
+  /* "../../../pyenv/scikit-allel-py37/lib/python3.7/site-packages/Cython/Includes/numpy/__init__.pxd":1023
  * 
  * cdef inline void set_array_base(ndarray arr, object base):
  *     Py_INCREF(base) # important to do this before stealing the reference below!             # <<<<<<<<<<<<<<
@@ -35736,7 +35736,7 @@ static CYTHON_INLINE void __pyx_f_5numpy_set_array_base(PyArrayObject *__pyx_v_a
  */
   Py_INCREF(__pyx_v_base);
 
-  /* ".tox/py37/lib/python3.7/site-packages/Cython/Includes/numpy/__init__.pxd":1024
+  /* "../../../pyenv/scikit-allel-py37/lib/python3.7/site-packages/Cython/Includes/numpy/__init__.pxd":1024
  * cdef inline void set_array_base(ndarray arr, object base):
  *     Py_INCREF(base) # important to do this before stealing the reference below!
  *     PyArray_SetBaseObject(arr, base)             # <<<<<<<<<<<<<<
@@ -35745,7 +35745,7 @@ static CYTHON_INLINE void __pyx_f_5numpy_set_array_base(PyArrayObject *__pyx_v_a
  */
   (void)(PyArray_SetBaseObject(__pyx_v_arr, __pyx_v_base));
 
-  /* ".tox/py37/lib/python3.7/site-packages/Cython/Includes/numpy/__init__.pxd":1022
+  /* "../../../pyenv/scikit-allel-py37/lib/python3.7/site-packages/Cython/Includes/numpy/__init__.pxd":1022
  *     int _import_umath() except -1
  * 
  * cdef inline void set_array_base(ndarray arr, object base):             # <<<<<<<<<<<<<<
@@ -35757,7 +35757,7 @@ static CYTHON_INLINE void __pyx_f_5numpy_set_array_base(PyArrayObject *__pyx_v_a
   __Pyx_RefNannyFinishContext();
 }
 
-/* ".tox/py37/lib/python3.7/site-packages/Cython/Includes/numpy/__init__.pxd":1026
+/* "../../../pyenv/scikit-allel-py37/lib/python3.7/site-packages/Cython/Includes/numpy/__init__.pxd":1026
  *     PyArray_SetBaseObject(arr, base)
  * 
  * cdef inline object get_array_base(ndarray arr):             # <<<<<<<<<<<<<<
@@ -35772,7 +35772,7 @@ static CYTHON_INLINE PyObject *__pyx_f_5numpy_get_array_base(PyArrayObject *__py
   int __pyx_t_1;
   __Pyx_RefNannySetupContext("get_array_base", 0);
 
-  /* ".tox/py37/lib/python3.7/site-packages/Cython/Includes/numpy/__init__.pxd":1027
+  /* "../../../pyenv/scikit-allel-py37/lib/python3.7/site-packages/Cython/Includes/numpy/__init__.pxd":1027
  * 
  * cdef inline object get_array_base(ndarray arr):
  *     base = PyArray_BASE(arr)             # <<<<<<<<<<<<<<
@@ -35781,7 +35781,7 @@ static CYTHON_INLINE PyObject *__pyx_f_5numpy_get_array_base(PyArrayObject *__py
  */
   __pyx_v_base = PyArray_BASE(__pyx_v_arr);
 
-  /* ".tox/py37/lib/python3.7/site-packages/Cython/Includes/numpy/__init__.pxd":1028
+  /* "../../../pyenv/scikit-allel-py37/lib/python3.7/site-packages/Cython/Includes/numpy/__init__.pxd":1028
  * cdef inline object get_array_base(ndarray arr):
  *     base = PyArray_BASE(arr)
  *     if base is NULL:             # <<<<<<<<<<<<<<
@@ -35791,7 +35791,7 @@ static CYTHON_INLINE PyObject *__pyx_f_5numpy_get_array_base(PyArrayObject *__py
   __pyx_t_1 = ((__pyx_v_base == NULL) != 0);
   if (__pyx_t_1) {
 
-    /* ".tox/py37/lib/python3.7/site-packages/Cython/Includes/numpy/__init__.pxd":1029
+    /* "../../../pyenv/scikit-allel-py37/lib/python3.7/site-packages/Cython/Includes/numpy/__init__.pxd":1029
  *     base = PyArray_BASE(arr)
  *     if base is NULL:
  *         return None             # <<<<<<<<<<<<<<
@@ -35802,7 +35802,7 @@ static CYTHON_INLINE PyObject *__pyx_f_5numpy_get_array_base(PyArrayObject *__py
     __pyx_r = Py_None; __Pyx_INCREF(Py_None);
     goto __pyx_L0;
 
-    /* ".tox/py37/lib/python3.7/site-packages/Cython/Includes/numpy/__init__.pxd":1028
+    /* "../../../pyenv/scikit-allel-py37/lib/python3.7/site-packages/Cython/Includes/numpy/__init__.pxd":1028
  * cdef inline object get_array_base(ndarray arr):
  *     base = PyArray_BASE(arr)
  *     if base is NULL:             # <<<<<<<<<<<<<<
@@ -35811,7 +35811,7 @@ static CYTHON_INLINE PyObject *__pyx_f_5numpy_get_array_base(PyArrayObject *__py
  */
   }
 
-  /* ".tox/py37/lib/python3.7/site-packages/Cython/Includes/numpy/__init__.pxd":1030
+  /* "../../../pyenv/scikit-allel-py37/lib/python3.7/site-packages/Cython/Includes/numpy/__init__.pxd":1030
  *     if base is NULL:
  *         return None
  *     return <object>base             # <<<<<<<<<<<<<<
@@ -35823,7 +35823,7 @@ static CYTHON_INLINE PyObject *__pyx_f_5numpy_get_array_base(PyArrayObject *__py
   __pyx_r = ((PyObject *)__pyx_v_base);
   goto __pyx_L0;
 
-  /* ".tox/py37/lib/python3.7/site-packages/Cython/Includes/numpy/__init__.pxd":1026
+  /* "../../../pyenv/scikit-allel-py37/lib/python3.7/site-packages/Cython/Includes/numpy/__init__.pxd":1026
  *     PyArray_SetBaseObject(arr, base)
  * 
  * cdef inline object get_array_base(ndarray arr):             # <<<<<<<<<<<<<<
@@ -35838,7 +35838,7 @@ static CYTHON_INLINE PyObject *__pyx_f_5numpy_get_array_base(PyArrayObject *__py
   return __pyx_r;
 }
 
-/* ".tox/py37/lib/python3.7/site-packages/Cython/Includes/numpy/__init__.pxd":1034
+/* "../../../pyenv/scikit-allel-py37/lib/python3.7/site-packages/Cython/Includes/numpy/__init__.pxd":1034
  * # Versions of the import_* functions which are more suitable for
  * # Cython code.
  * cdef inline int import_array() except -1:             # <<<<<<<<<<<<<<
@@ -35859,7 +35859,7 @@ static CYTHON_INLINE int __pyx_f_5numpy_import_array(void) {
   PyObject *__pyx_t_8 = NULL;
   __Pyx_RefNannySetupContext("import_array", 0);
 
-  /* ".tox/py37/lib/python3.7/site-packages/Cython/Includes/numpy/__init__.pxd":1035
+  /* "../../../pyenv/scikit-allel-py37/lib/python3.7/site-packages/Cython/Includes/numpy/__init__.pxd":1035
  * # Cython code.
  * cdef inline int import_array() except -1:
  *     try:             # <<<<<<<<<<<<<<
@@ -35875,7 +35875,7 @@ static CYTHON_INLINE int __pyx_f_5numpy_import_array(void) {
     __Pyx_XGOTREF(__pyx_t_3);
     /*try:*/ {
 
-      /* ".tox/py37/lib/python3.7/site-packages/Cython/Includes/numpy/__init__.pxd":1036
+      /* "../../../pyenv/scikit-allel-py37/lib/python3.7/site-packages/Cython/Includes/numpy/__init__.pxd":1036
  * cdef inline int import_array() except -1:
  *     try:
  *         _import_array()             # <<<<<<<<<<<<<<
@@ -35884,7 +35884,7 @@ static CYTHON_INLINE int __pyx_f_5numpy_import_array(void) {
  */
       __pyx_t_4 = _import_array(); if (unlikely(__pyx_t_4 == ((int)-1))) __PYX_ERR(1, 1036, __pyx_L3_error)
 
-      /* ".tox/py37/lib/python3.7/site-packages/Cython/Includes/numpy/__init__.pxd":1035
+      /* "../../../pyenv/scikit-allel-py37/lib/python3.7/site-packages/Cython/Includes/numpy/__init__.pxd":1035
  * # Cython code.
  * cdef inline int import_array() except -1:
  *     try:             # <<<<<<<<<<<<<<
@@ -35898,7 +35898,7 @@ static CYTHON_INLINE int __pyx_f_5numpy_import_array(void) {
     goto __pyx_L8_try_end;
     __pyx_L3_error:;
 
-    /* ".tox/py37/lib/python3.7/site-packages/Cython/Includes/numpy/__init__.pxd":1037
+    /* "../../../pyenv/scikit-allel-py37/lib/python3.7/site-packages/Cython/Includes/numpy/__init__.pxd":1037
  *     try:
  *         _import_array()
  *     except Exception:             # <<<<<<<<<<<<<<
@@ -35913,7 +35913,7 @@ static CYTHON_INLINE int __pyx_f_5numpy_import_array(void) {
       __Pyx_GOTREF(__pyx_t_6);
       __Pyx_GOTREF(__pyx_t_7);
 
-      /* ".tox/py37/lib/python3.7/site-packages/Cython/Includes/numpy/__init__.pxd":1038
+      /* "../../../pyenv/scikit-allel-py37/lib/python3.7/site-packages/Cython/Includes/numpy/__init__.pxd":1038
  *         _import_array()
  *     except Exception:
  *         raise ImportError("numpy.core.multiarray failed to import")             # <<<<<<<<<<<<<<
@@ -35929,7 +35929,7 @@ static CYTHON_INLINE int __pyx_f_5numpy_import_array(void) {
     goto __pyx_L5_except_error;
     __pyx_L5_except_error:;
 
-    /* ".tox/py37/lib/python3.7/site-packages/Cython/Includes/numpy/__init__.pxd":1035
+    /* "../../../pyenv/scikit-allel-py37/lib/python3.7/site-packages/Cython/Includes/numpy/__init__.pxd":1035
  * # Cython code.
  * cdef inline int import_array() except -1:
  *     try:             # <<<<<<<<<<<<<<
@@ -35944,7 +35944,7 @@ static CYTHON_INLINE int __pyx_f_5numpy_import_array(void) {
     __pyx_L8_try_end:;
   }
 
-  /* ".tox/py37/lib/python3.7/site-packages/Cython/Includes/numpy/__init__.pxd":1034
+  /* "../../../pyenv/scikit-allel-py37/lib/python3.7/site-packages/Cython/Includes/numpy/__init__.pxd":1034
  * # Versions of the import_* functions which are more suitable for
  * # Cython code.
  * cdef inline int import_array() except -1:             # <<<<<<<<<<<<<<
@@ -35967,7 +35967,7 @@ static CYTHON_INLINE int __pyx_f_5numpy_import_array(void) {
   return __pyx_r;
 }
 
-/* ".tox/py37/lib/python3.7/site-packages/Cython/Includes/numpy/__init__.pxd":1040
+/* "../../../pyenv/scikit-allel-py37/lib/python3.7/site-packages/Cython/Includes/numpy/__init__.pxd":1040
  *         raise ImportError("numpy.core.multiarray failed to import")
  * 
  * cdef inline int import_umath() except -1:             # <<<<<<<<<<<<<<
@@ -35988,7 +35988,7 @@ static CYTHON_INLINE int __pyx_f_5numpy_import_umath(void) {
   PyObject *__pyx_t_8 = NULL;
   __Pyx_RefNannySetupContext("import_umath", 0);
 
-  /* ".tox/py37/lib/python3.7/site-packages/Cython/Includes/numpy/__init__.pxd":1041
+  /* "../../../pyenv/scikit-allel-py37/lib/python3.7/site-packages/Cython/Includes/numpy/__init__.pxd":1041
  * 
  * cdef inline int import_umath() except -1:
  *     try:             # <<<<<<<<<<<<<<
@@ -36004,7 +36004,7 @@ static CYTHON_INLINE int __pyx_f_5numpy_import_umath(void) {
     __Pyx_XGOTREF(__pyx_t_3);
     /*try:*/ {
 
-      /* ".tox/py37/lib/python3.7/site-packages/Cython/Includes/numpy/__init__.pxd":1042
+      /* "../../../pyenv/scikit-allel-py37/lib/python3.7/site-packages/Cython/Includes/numpy/__init__.pxd":1042
  * cdef inline int import_umath() except -1:
  *     try:
  *         _import_umath()             # <<<<<<<<<<<<<<
@@ -36013,7 +36013,7 @@ static CYTHON_INLINE int __pyx_f_5numpy_import_umath(void) {
  */
       __pyx_t_4 = _import_umath(); if (unlikely(__pyx_t_4 == ((int)-1))) __PYX_ERR(1, 1042, __pyx_L3_error)
 
-      /* ".tox/py37/lib/python3.7/site-packages/Cython/Includes/numpy/__init__.pxd":1041
+      /* "../../../pyenv/scikit-allel-py37/lib/python3.7/site-packages/Cython/Includes/numpy/__init__.pxd":1041
  * 
  * cdef inline int import_umath() except -1:
  *     try:             # <<<<<<<<<<<<<<
@@ -36027,7 +36027,7 @@ static CYTHON_INLINE int __pyx_f_5numpy_import_umath(void) {
     goto __pyx_L8_try_end;
     __pyx_L3_error:;
 
-    /* ".tox/py37/lib/python3.7/site-packages/Cython/Includes/numpy/__init__.pxd":1043
+    /* "../../../pyenv/scikit-allel-py37/lib/python3.7/site-packages/Cython/Includes/numpy/__init__.pxd":1043
  *     try:
  *         _import_umath()
  *     except Exception:             # <<<<<<<<<<<<<<
@@ -36042,7 +36042,7 @@ static CYTHON_INLINE int __pyx_f_5numpy_import_umath(void) {
       __Pyx_GOTREF(__pyx_t_6);
       __Pyx_GOTREF(__pyx_t_7);
 
-      /* ".tox/py37/lib/python3.7/site-packages/Cython/Includes/numpy/__init__.pxd":1044
+      /* "../../../pyenv/scikit-allel-py37/lib/python3.7/site-packages/Cython/Includes/numpy/__init__.pxd":1044
  *         _import_umath()
  *     except Exception:
  *         raise ImportError("numpy.core.umath failed to import")             # <<<<<<<<<<<<<<
@@ -36058,7 +36058,7 @@ static CYTHON_INLINE int __pyx_f_5numpy_import_umath(void) {
     goto __pyx_L5_except_error;
     __pyx_L5_except_error:;
 
-    /* ".tox/py37/lib/python3.7/site-packages/Cython/Includes/numpy/__init__.pxd":1041
+    /* "../../../pyenv/scikit-allel-py37/lib/python3.7/site-packages/Cython/Includes/numpy/__init__.pxd":1041
  * 
  * cdef inline int import_umath() except -1:
  *     try:             # <<<<<<<<<<<<<<
@@ -36073,7 +36073,7 @@ static CYTHON_INLINE int __pyx_f_5numpy_import_umath(void) {
     __pyx_L8_try_end:;
   }
 
-  /* ".tox/py37/lib/python3.7/site-packages/Cython/Includes/numpy/__init__.pxd":1040
+  /* "../../../pyenv/scikit-allel-py37/lib/python3.7/site-packages/Cython/Includes/numpy/__init__.pxd":1040
  *         raise ImportError("numpy.core.multiarray failed to import")
  * 
  * cdef inline int import_umath() except -1:             # <<<<<<<<<<<<<<
@@ -36096,7 +36096,7 @@ static CYTHON_INLINE int __pyx_f_5numpy_import_umath(void) {
   return __pyx_r;
 }
 
-/* ".tox/py37/lib/python3.7/site-packages/Cython/Includes/numpy/__init__.pxd":1046
+/* "../../../pyenv/scikit-allel-py37/lib/python3.7/site-packages/Cython/Includes/numpy/__init__.pxd":1046
  *         raise ImportError("numpy.core.umath failed to import")
  * 
  * cdef inline int import_ufunc() except -1:             # <<<<<<<<<<<<<<
@@ -36117,7 +36117,7 @@ static CYTHON_INLINE int __pyx_f_5numpy_import_ufunc(void) {
   PyObject *__pyx_t_8 = NULL;
   __Pyx_RefNannySetupContext("import_ufunc", 0);
 
-  /* ".tox/py37/lib/python3.7/site-packages/Cython/Includes/numpy/__init__.pxd":1047
+  /* "../../../pyenv/scikit-allel-py37/lib/python3.7/site-packages/Cython/Includes/numpy/__init__.pxd":1047
  * 
  * cdef inline int import_ufunc() except -1:
  *     try:             # <<<<<<<<<<<<<<
@@ -36133,7 +36133,7 @@ static CYTHON_INLINE int __pyx_f_5numpy_import_ufunc(void) {
     __Pyx_XGOTREF(__pyx_t_3);
     /*try:*/ {
 
-      /* ".tox/py37/lib/python3.7/site-packages/Cython/Includes/numpy/__init__.pxd":1048
+      /* "../../../pyenv/scikit-allel-py37/lib/python3.7/site-packages/Cython/Includes/numpy/__init__.pxd":1048
  * cdef inline int import_ufunc() except -1:
  *     try:
  *         _import_umath()             # <<<<<<<<<<<<<<
@@ -36142,7 +36142,7 @@ static CYTHON_INLINE int __pyx_f_5numpy_import_ufunc(void) {
  */
       __pyx_t_4 = _import_umath(); if (unlikely(__pyx_t_4 == ((int)-1))) __PYX_ERR(1, 1048, __pyx_L3_error)
 
-      /* ".tox/py37/lib/python3.7/site-packages/Cython/Includes/numpy/__init__.pxd":1047
+      /* "../../../pyenv/scikit-allel-py37/lib/python3.7/site-packages/Cython/Includes/numpy/__init__.pxd":1047
  * 
  * cdef inline int import_ufunc() except -1:
  *     try:             # <<<<<<<<<<<<<<
@@ -36156,7 +36156,7 @@ static CYTHON_INLINE int __pyx_f_5numpy_import_ufunc(void) {
     goto __pyx_L8_try_end;
     __pyx_L3_error:;
 
-    /* ".tox/py37/lib/python3.7/site-packages/Cython/Includes/numpy/__init__.pxd":1049
+    /* "../../../pyenv/scikit-allel-py37/lib/python3.7/site-packages/Cython/Includes/numpy/__init__.pxd":1049
  *     try:
  *         _import_umath()
  *     except Exception:             # <<<<<<<<<<<<<<
@@ -36170,7 +36170,7 @@ static CYTHON_INLINE int __pyx_f_5numpy_import_ufunc(void) {
       __Pyx_GOTREF(__pyx_t_6);
       __Pyx_GOTREF(__pyx_t_7);
 
-      /* ".tox/py37/lib/python3.7/site-packages/Cython/Includes/numpy/__init__.pxd":1050
+      /* "../../../pyenv/scikit-allel-py37/lib/python3.7/site-packages/Cython/Includes/numpy/__init__.pxd":1050
  *         _import_umath()
  *     except Exception:
  *         raise ImportError("numpy.core.umath failed to import")             # <<<<<<<<<<<<<<
@@ -36184,7 +36184,7 @@ static CYTHON_INLINE int __pyx_f_5numpy_import_ufunc(void) {
     goto __pyx_L5_except_error;
     __pyx_L5_except_error:;
 
-    /* ".tox/py37/lib/python3.7/site-packages/Cython/Includes/numpy/__init__.pxd":1047
+    /* "../../../pyenv/scikit-allel-py37/lib/python3.7/site-packages/Cython/Includes/numpy/__init__.pxd":1047
  * 
  * cdef inline int import_ufunc() except -1:
  *     try:             # <<<<<<<<<<<<<<
@@ -36199,7 +36199,7 @@ static CYTHON_INLINE int __pyx_f_5numpy_import_ufunc(void) {
     __pyx_L8_try_end:;
   }
 
-  /* ".tox/py37/lib/python3.7/site-packages/Cython/Includes/numpy/__init__.pxd":1046
+  /* "../../../pyenv/scikit-allel-py37/lib/python3.7/site-packages/Cython/Includes/numpy/__init__.pxd":1046
  *         raise ImportError("numpy.core.umath failed to import")
  * 
  * cdef inline int import_ufunc() except -1:             # <<<<<<<<<<<<<<
@@ -50006,7 +50006,7 @@ static CYTHON_SMALL_CODE int __Pyx_InitCachedConstants(void) {
   __Pyx_GOTREF(__pyx_tuple__5);
   __Pyx_GIVEREF(__pyx_tuple__5);
 
-  /* ".tox/py37/lib/python3.7/site-packages/Cython/Includes/numpy/__init__.pxd":272
+  /* "../../../pyenv/scikit-allel-py37/lib/python3.7/site-packages/Cython/Includes/numpy/__init__.pxd":272
  *             if ((flags & pybuf.PyBUF_C_CONTIGUOUS == pybuf.PyBUF_C_CONTIGUOUS)
  *                 and not PyArray_CHKFLAGS(self, NPY_ARRAY_C_CONTIGUOUS)):
  *                 raise ValueError(u"ndarray is not C contiguous")             # <<<<<<<<<<<<<<
@@ -50017,7 +50017,7 @@ static CYTHON_SMALL_CODE int __Pyx_InitCachedConstants(void) {
   __Pyx_GOTREF(__pyx_tuple__7);
   __Pyx_GIVEREF(__pyx_tuple__7);
 
-  /* ".tox/py37/lib/python3.7/site-packages/Cython/Includes/numpy/__init__.pxd":276
+  /* "../../../pyenv/scikit-allel-py37/lib/python3.7/site-packages/Cython/Includes/numpy/__init__.pxd":276
  *             if ((flags & pybuf.PyBUF_F_CONTIGUOUS == pybuf.PyBUF_F_CONTIGUOUS)
  *                 and not PyArray_CHKFLAGS(self, NPY_ARRAY_F_CONTIGUOUS)):
  *                 raise ValueError(u"ndarray is not Fortran contiguous")             # <<<<<<<<<<<<<<
@@ -50028,7 +50028,7 @@ static CYTHON_SMALL_CODE int __Pyx_InitCachedConstants(void) {
   __Pyx_GOTREF(__pyx_tuple__8);
   __Pyx_GIVEREF(__pyx_tuple__8);
 
-  /* ".tox/py37/lib/python3.7/site-packages/Cython/Includes/numpy/__init__.pxd":306
+  /* "../../../pyenv/scikit-allel-py37/lib/python3.7/site-packages/Cython/Includes/numpy/__init__.pxd":306
  *                 if ((descr.byteorder == c'>' and little_endian) or
  *                     (descr.byteorder == c'<' and not little_endian)):
  *                     raise ValueError(u"Non-native byte order not supported")             # <<<<<<<<<<<<<<
@@ -50039,7 +50039,7 @@ static CYTHON_SMALL_CODE int __Pyx_InitCachedConstants(void) {
   __Pyx_GOTREF(__pyx_tuple__9);
   __Pyx_GIVEREF(__pyx_tuple__9);
 
-  /* ".tox/py37/lib/python3.7/site-packages/Cython/Includes/numpy/__init__.pxd":856
+  /* "../../../pyenv/scikit-allel-py37/lib/python3.7/site-packages/Cython/Includes/numpy/__init__.pxd":856
  * 
  *         if (end - f) - <int>(new_offset - offset[0]) < 15:
  *             raise RuntimeError(u"Format string allocated too short, see comment in numpy.pxd")             # <<<<<<<<<<<<<<
@@ -50050,7 +50050,7 @@ static CYTHON_SMALL_CODE int __Pyx_InitCachedConstants(void) {
   __Pyx_GOTREF(__pyx_tuple__10);
   __Pyx_GIVEREF(__pyx_tuple__10);
 
-  /* ".tox/py37/lib/python3.7/site-packages/Cython/Includes/numpy/__init__.pxd":860
+  /* "../../../pyenv/scikit-allel-py37/lib/python3.7/site-packages/Cython/Includes/numpy/__init__.pxd":860
  *         if ((child.byteorder == c'>' and little_endian) or
  *             (child.byteorder == c'<' and not little_endian)):
  *             raise ValueError(u"Non-native byte order not supported")             # <<<<<<<<<<<<<<
@@ -50061,7 +50061,7 @@ static CYTHON_SMALL_CODE int __Pyx_InitCachedConstants(void) {
   __Pyx_GOTREF(__pyx_tuple__9);
   __Pyx_GIVEREF(__pyx_tuple__9);
 
-  /* ".tox/py37/lib/python3.7/site-packages/Cython/Includes/numpy/__init__.pxd":880
+  /* "../../../pyenv/scikit-allel-py37/lib/python3.7/site-packages/Cython/Includes/numpy/__init__.pxd":880
  *             t = child.type_num
  *             if end - f < 5:
  *                 raise RuntimeError(u"Format string allocated too short.")             # <<<<<<<<<<<<<<
@@ -50072,7 +50072,7 @@ static CYTHON_SMALL_CODE int __Pyx_InitCachedConstants(void) {
   __Pyx_GOTREF(__pyx_tuple__11);
   __Pyx_GIVEREF(__pyx_tuple__11);
 
-  /* ".tox/py37/lib/python3.7/site-packages/Cython/Includes/numpy/__init__.pxd":1038
+  /* "../../../pyenv/scikit-allel-py37/lib/python3.7/site-packages/Cython/Includes/numpy/__init__.pxd":1038
  *         _import_array()
  *     except Exception:
  *         raise ImportError("numpy.core.multiarray failed to import")             # <<<<<<<<<<<<<<
@@ -50083,7 +50083,7 @@ static CYTHON_SMALL_CODE int __Pyx_InitCachedConstants(void) {
   __Pyx_GOTREF(__pyx_tuple__12);
   __Pyx_GIVEREF(__pyx_tuple__12);
 
-  /* ".tox/py37/lib/python3.7/site-packages/Cython/Includes/numpy/__init__.pxd":1044
+  /* "../../../pyenv/scikit-allel-py37/lib/python3.7/site-packages/Cython/Includes/numpy/__init__.pxd":1044
  *         _import_umath()
  *     except Exception:
  *         raise ImportError("numpy.core.umath failed to import")             # <<<<<<<<<<<<<<
@@ -50094,7 +50094,7 @@ static CYTHON_SMALL_CODE int __Pyx_InitCachedConstants(void) {
   __Pyx_GOTREF(__pyx_tuple__13);
   __Pyx_GIVEREF(__pyx_tuple__13);
 
-  /* ".tox/py37/lib/python3.7/site-packages/Cython/Includes/numpy/__init__.pxd":1050
+  /* "../../../pyenv/scikit-allel-py37/lib/python3.7/site-packages/Cython/Includes/numpy/__init__.pxd":1050
  *         _import_umath()
  *     except Exception:
  *         raise ImportError("numpy.core.umath failed to import")             # <<<<<<<<<<<<<<

--- a/allel/test/data/altlen.vcf
+++ b/allel/test/data/altlen.vcf
@@ -11,7 +11,7 @@
 ##INFO=<ID=AA,Number=1,Type=String,Description="Ancestral Allele">
 ##INFO=<ID=DB,Number=0,Type=Flag,Description="dbSNP membership, build 129">
 ##INFO=<ID=H2,Number=0,Type=Flag,Description="HapMap2 membership">
-##INFO=<ID=SVLEN,Number=1,Type=Integer,Description="structural variant length">
+##INFO=<ID=ALTLEN,Number=1,Type=Integer,Description="ALT length">
 ##FILTER=<ID=s50,Description="Less than 50% of samples have data">
 ##FILTER=<ID=q10,Description="Quality below 10">
 ##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">
@@ -24,7 +24,7 @@
 19	111	.	A	C	9.6	.	.	GT:HQ	0|0:10,15	0|0:10,10	0/1:3,3
 19	112	.	A	G	10	.	.	GT:HQ	0|0:10,10	0|0:10,10	0/1:3,3
 20	14370	rs6054257	G	A	29	PASS	NS=3;DP=14;AF=0.5;DB;H2	GT:GQ:DP:HQ	0|0:48:1:51,51	1|0:48:8:51,51	1/1:43:5:.,.
-20	17330	.	T	TAAA	3	q10	SVLEN=3;NS=3;DP=11;AF=0.017	GT:GQ:DP:HQ	0|0:49:3:58,50	0|1:3:5:65,3	0/0:41:3:.,.
+20	17330	.	T	TAAA	3	q10	ALTLEN=3;NS=3;DP=11;AF=0.017	GT:GQ:DP:HQ	0|0:49:3:58,50	0|1:3:5:65,3	0/0:41:3:.,.
 20	1110696	rs6040355	A	G,T	67	PASS	NS=2;DP=10;AF=0.333,0.667;AA=T;DB	GT:GQ:DP:HQ	1|2:21:6:23,27	2|1:2:0:18,2	2/2:35:4:.,.
 20	1230237	.	T	.	47	PASS	NS=3;DP=13;AA=T	GT:GQ:DP:HQ	0|0:54:.:56,60	0|0:48:4:51,51	0/0:61:2:.,.
 20	1234567	microsat1	G	GA,GAC	50	PASS	NS=3;DP=9;AA=G;AN=6;AC=3,1	GT:GQ:DP	0/1:.:4	0/2:17:2	./.:40:3

--- a/allel/test/data/svlen.vcf
+++ b/allel/test/data/svlen.vcf
@@ -1,0 +1,32 @@
+##fileformat=VCFv4.0
+##fileDate=20090805
+##source=myImputationProgramV3.1
+##reference=1000GenomesPilot-NCBI36
+##phasing=partial
+##INFO=<ID=NS,Number=1,Type=Integer,Description="Number of Samples With Data">
+##INFO=<ID=AN,Number=1,Type=Integer,Description="Total number of alleles in called genotypes">
+##INFO=<ID=AC,Number=.,Type=Integer,Description="Allele count in genotypes, for each ALT allele, in the same order as listed">
+##INFO=<ID=DP,Number=1,Type=Integer,Description="Total Depth">
+##INFO=<ID=AF,Number=.,Type=Float,Description="Allele Frequency">
+##INFO=<ID=AA,Number=1,Type=String,Description="Ancestral Allele">
+##INFO=<ID=DB,Number=0,Type=Flag,Description="dbSNP membership, build 129">
+##INFO=<ID=H2,Number=0,Type=Flag,Description="HapMap2 membership">
+##INFO=<ID=SVLEN,Number=1,Type=Integer,Description="structural variant length">
+##FILTER=<ID=s50,Description="Less than 50% of samples have data">
+##FILTER=<ID=q10,Description="Quality below 10">
+##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">
+##FORMAT=<ID=GQ,Number=1,Type=Integer,Description="Genotype Quality">
+##FORMAT=<ID=DP,Number=1,Type=Integer,Description="Read Depth">
+##FORMAT=<ID=HQ,Number=2,Type=Integer,Description="Haplotype Quality">
+##ALT=<ID=DEL:ME:ALU,Description="Deletion of ALU element">
+##ALT=<ID=CNV,Description="Copy number variable region">
+#CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO	FORMAT	NA00001	NA00002	NA00003
+19	111	.	A	C	9.6	.	.	GT:HQ	0|0:10,15	0|0:10,10	0/1:3,3
+19	112	.	A	G	10	.	.	GT:HQ	0|0:10,10	0|0:10,10	0/1:3,3
+20	14370	rs6054257	G	A	29	PASS	NS=3;DP=14;AF=0.5;DB;H2	GT:GQ:DP:HQ	0|0:48:1:51,51	1|0:48:8:51,51	1/1:43:5:.,.
+20	17330	.	T	TAAA	3	q10	SVLEN=3;NS=3;DP=11;AF=0.017	GT:GQ:DP:HQ	0|0:49:3:58,50	0|1:3:5:65,3	0/0:41:3:.,.
+20	1110696	rs6040355	A	G,T	67	PASS	NS=2;DP=10;AF=0.333,0.667;AA=T;DB	GT:GQ:DP:HQ	1|2:21:6:23,27	2|1:2:0:18,2	2/2:35:4:.,.
+20	1230237	.	T	.	47	PASS	NS=3;DP=13;AA=T	GT:GQ:DP:HQ	0|0:54:.:56,60	0|0:48:4:51,51	0/0:61:2:.,.
+20	1234567	microsat1	G	GA,GAC	50	PASS	NS=3;DP=9;AA=G;AN=6;AC=3,1	GT:GQ:DP	0/1:.:4	0/2:17:2	./.:40:3
+20	1235237	.	T	.	.	.	.	GT	0/0	0|0	./.
+X	10	rsTest	AC	A,ATG,C	10	PASS	.	GT	0	0/1	0|2

--- a/allel/test/model/test_api.py
+++ b/allel/test/model/test_api.py
@@ -2459,8 +2459,6 @@ chr3\t1\te\tN\tX\t5.6\tPASS\tDP=56;QD=56.7;ac=9;flg;xx=9.0,9.9
         actual_vcf = open(f.name).read()
         # compare line-by-line
         for l1, l2 in zip(expect_vcf.split('\n'), actual_vcf.split('\n')):
-            print('expect:', l1)
-            print('actual:', l2)
             eq(l1, l2)
 
     def test_to_vcf_no_filters(self):
@@ -2538,8 +2536,6 @@ chr3\t1\te\tN\tX\t5.6\t.\tDP=56;QD=56.7;ac=9;flg;xx=9.0,9.9
         actual_vcf = open(f.name).read()
         # compare line-by-line
         for l1, l2 in zip(expect_vcf.split('\n'), actual_vcf.split('\n')):
-            print('expect:', l1)
-            print('actual:', l2)
             eq(l1, l2)
 
     def test_to_vcf_no_info(self):
@@ -2598,8 +2594,6 @@ chr3\t1\te\tN\tX\t5.6\t.\t.
         actual_vcf = open(f.name).read()
         # compare line-by-line
         for l1, l2 in zip(expect_vcf.split('\n'), actual_vcf.split('\n')):
-            print('expect:', l1)
-            print('actual:', l2)
             eq(l1, l2)
 
 

--- a/allel/test/stats/test_selection.py
+++ b/allel/test/stats/test_selection.py
@@ -4,7 +4,7 @@ from __future__ import absolute_import, print_function, division
 
 import numpy as np
 from nose.tools import eq_ as eq, assert_is_instance, assert_raises
-from allel.test.tools import assert_array_equal, assert_array_nanclose
+from allel.test.tools import assert_array_equal, assert_array_almost_equal
 
 
 from allel import ihs, xpehh, nsl, xpnsl, ehh_decay, voight_painting, pbs
@@ -104,9 +104,9 @@ def test_nsl01_scan_a():
                   [0, 0, 0, 1, 1, 1]])
     nsl0, nsl1 = nsl01_scan(h)
     expect_nsl0 = [1, 2, 3, 4]
-    assert_array_nanclose(expect_nsl0, nsl0)
+    assert_array_almost_equal(expect_nsl0, nsl0)
     expect_nsl1 = [1, 2, 3, 4]
-    assert_array_nanclose(expect_nsl1, nsl1)
+    assert_array_almost_equal(expect_nsl1, nsl1)
 
 
 def test_nsl01_scan_b():
@@ -117,9 +117,9 @@ def test_nsl01_scan_b():
                   [1, 0, 0, 0]])
     nsl0, nsl1 = nsl01_scan(h)
     expect_nsl0 = [1, 4 / 3, 4 / 3, 4 / 3]
-    assert_array_nanclose(expect_nsl0, nsl0)
+    assert_array_almost_equal(expect_nsl0, nsl0)
     expect_nsl1 = [np.nan, np.nan, np.nan, np.nan]
-    assert_array_nanclose(expect_nsl1, nsl1)
+    assert_array_almost_equal(expect_nsl1, nsl1)
 
 
 def test_nsl01_scan_c():
@@ -130,9 +130,9 @@ def test_nsl01_scan_c():
                   [1, 0, 0]])
     nsl0, nsl1 = nsl01_scan(h)
     expect_nsl0 = [1, np.nan, np.nan, 1]
-    assert_array_nanclose(expect_nsl0, nsl0)
+    assert_array_almost_equal(expect_nsl0, nsl0)
     expect_nsl1 = [np.nan, 1, 1, np.nan]
-    assert_array_nanclose(expect_nsl1, nsl1)
+    assert_array_almost_equal(expect_nsl1, nsl1)
 
 
 def test_ihh_scan_a():
@@ -145,12 +145,12 @@ def test_ihh_scan_a():
     # do not include edges
     expect = [np.nan, np.nan, np.nan]
     actual = ihh_scan(h, gaps, min_ehh=0, include_edges=False)
-    assert_array_nanclose(expect, actual)
+    assert_array_almost_equal(expect, actual)
 
     # include edges
     expect = [0, 10, 20]
     actual = ihh_scan(h, gaps, min_ehh=0, include_edges=True)
-    assert_array_nanclose(expect, actual)
+    assert_array_almost_equal(expect, actual)
 
 
 def test_ihh_scan_b():
@@ -164,12 +164,12 @@ def test_ihh_scan_b():
     # do not include edges
     expect = [np.nan, np.nan, np.nan]
     actual = ihh_scan(h, gaps, min_ehh=0, include_edges=False)
-    assert_array_nanclose(expect, actual)
+    assert_array_almost_equal(expect, actual)
 
     # include edges
     expect = [0, 10, np.nan]
     actual = ihh_scan(h, gaps, min_ehh=0, include_edges=True)
-    assert_array_nanclose(expect, actual)
+    assert_array_almost_equal(expect, actual)
 
 
 def test_ihh_scan_c():
@@ -182,12 +182,12 @@ def test_ihh_scan_c():
     # do not include edges
     expect = [0, 5, 15]
     actual = ihh_scan(h, gaps, min_ehh=0, include_edges=False)
-    assert_array_nanclose(expect, actual)
+    assert_array_almost_equal(expect, actual)
 
     # include edges
     expect = [0, 5, 15]
     actual = ihh_scan(h, gaps, min_ehh=0, include_edges=True)
-    assert_array_nanclose(expect, actual)
+    assert_array_almost_equal(expect, actual)
 
 
 def test_ihh_scan_d():
@@ -198,11 +198,11 @@ def test_ihh_scan_d():
 
     expect = [0, 0]
     actual = ihh_scan(h, gaps, min_ehh=0, include_edges=False)
-    assert_array_nanclose(expect, actual)
+    assert_array_almost_equal(expect, actual)
 
     expect = [0, 0]
     actual = ihh_scan(h, gaps, min_ehh=0, include_edges=True)
-    assert_array_nanclose(expect, actual)
+    assert_array_almost_equal(expect, actual)
 
 
 def test_ihh_scan_e():
@@ -213,19 +213,19 @@ def test_ihh_scan_e():
 
     expect = [np.nan, 10/6]
     actual = ihh_scan(h, gaps, min_ehh=0, include_edges=False)
-    assert_array_nanclose(expect, actual)
+    assert_array_almost_equal(expect, actual)
 
     expect = [0, 10/6]
     actual = ihh_scan(h, gaps, min_ehh=0, include_edges=True)
-    assert_array_nanclose(expect, actual)
+    assert_array_almost_equal(expect, actual)
 
     expect = [0, 0]
     actual = ihh_scan(h, gaps, min_ehh=0.5, include_edges=False)
-    assert_array_nanclose(expect, actual)
+    assert_array_almost_equal(expect, actual)
 
     expect = [0, 0]
     actual = ihh_scan(h, gaps, min_ehh=0.5, include_edges=True)
-    assert_array_nanclose(expect, actual)
+    assert_array_almost_equal(expect, actual)
 
 
 def test_ihh01_scan_a():
@@ -237,15 +237,15 @@ def test_ihh01_scan_a():
 
     ihh0, ihh1 = ihh01_scan(h, gaps, min_ehh=0.05, include_edges=False)
     expect_ihh0 = [np.nan, np.nan, np.nan, 5]
-    assert_array_nanclose(expect_ihh0, ihh0)
+    assert_array_almost_equal(expect_ihh0, ihh0)
     expect_ihh1 = [np.nan, 5, 5, np.nan]
-    assert_array_nanclose(expect_ihh1, ihh1)
+    assert_array_almost_equal(expect_ihh1, ihh1)
 
     ihh0, ihh1 = ihh01_scan(h, gaps, min_ehh=0, include_edges=True)
     expect_ihh0 = [0, np.nan, np.nan, 5]
-    assert_array_nanclose(expect_ihh0, ihh0)
+    assert_array_almost_equal(expect_ihh0, ihh0)
     expect_ihh1 = [np.nan, 5, 5, np.nan]
-    assert_array_nanclose(expect_ihh1, ihh1)
+    assert_array_almost_equal(expect_ihh1, ihh1)
 
 
 def test_ihh01_scan_b():
@@ -258,21 +258,21 @@ def test_ihh01_scan_b():
     ihh0, ihh1 = ihh01_scan(h, gaps, min_ehh=0.05, include_edges=False)
     x = (10 * (1 + 1 / 3) / 2) + (10 * (1 / 3 + 0) / 2)
     expect_ihh0 = [np.nan, np.nan, x, x]
-    assert_array_nanclose(expect_ihh0, ihh0)
+    assert_array_almost_equal(expect_ihh0, ihh0)
     expect_ihh1 = [np.nan, np.nan, np.nan, np.nan]
-    assert_array_nanclose(expect_ihh1, ihh1)
+    assert_array_almost_equal(expect_ihh1, ihh1)
 
     ihh0, ihh1 = ihh01_scan(h, gaps, min_ehh=0, include_edges=False)
     expect_ihh0 = [np.nan, np.nan, x, x]
-    assert_array_nanclose(expect_ihh0, ihh0)
+    assert_array_almost_equal(expect_ihh0, ihh0)
     expect_ihh1 = [np.nan, np.nan, np.nan, np.nan]
-    assert_array_nanclose(expect_ihh1, ihh1)
+    assert_array_almost_equal(expect_ihh1, ihh1)
 
     ihh0, ihh1 = ihh01_scan(h, gaps, min_ehh=0, include_edges=True)
     expect_ihh0 = [0, 10 * (1 + 1 / 3) / 2, x, x]
-    assert_array_nanclose(expect_ihh0, ihh0)
+    assert_array_almost_equal(expect_ihh0, ihh0)
     expect_ihh1 = [np.nan, np.nan, np.nan, np.nan]
-    assert_array_nanclose(expect_ihh1, ihh1)
+    assert_array_almost_equal(expect_ihh1, ihh1)
 
 
 def test_ihh01_scan_c():
@@ -284,15 +284,15 @@ def test_ihh01_scan_c():
 
     ihh0, ihh1 = ihh01_scan(h, gaps, min_ehh=0.05)
     expect_ihh0 = [np.nan, np.nan, np.nan, np.nan]
-    assert_array_nanclose(expect_ihh0, ihh0)
+    assert_array_almost_equal(expect_ihh0, ihh0)
     expect_ihh1 = [np.nan, np.nan, np.nan, np.nan]
-    assert_array_nanclose(expect_ihh1, ihh1)
+    assert_array_almost_equal(expect_ihh1, ihh1)
 
     ihh0, ihh1 = ihh01_scan(h, gaps, min_ehh=0, include_edges=True)
     expect_ihh0 = [0, 10, 20, 30]
-    assert_array_nanclose(expect_ihh0, ihh0)
+    assert_array_almost_equal(expect_ihh0, ihh0)
     expect_ihh1 = [0, 10, 20, 30]
-    assert_array_nanclose(expect_ihh1, ihh1)
+    assert_array_almost_equal(expect_ihh1, ihh1)
 
 
 def test_ihh01_scan_d():
@@ -305,21 +305,21 @@ def test_ihh01_scan_d():
     ihh0, ihh1 = ihh01_scan(h, gaps, min_ehh=0.05)
     x = (10 * (1 + 1 / 3) / 2) + (10 * (1 / 3 + 0) / 2)
     expect_ihh0 = [np.nan, np.nan, x, x]
-    assert_array_nanclose(expect_ihh0, ihh0)
+    assert_array_almost_equal(expect_ihh0, ihh0)
     expect_ihh1 = [np.nan, np.nan, x, x]
-    assert_array_nanclose(expect_ihh1, ihh1)
+    assert_array_almost_equal(expect_ihh1, ihh1)
 
     ihh0, ihh1 = ihh01_scan(h, gaps, min_ehh=0)
     expect_ihh0 = [np.nan, np.nan, x, x]
-    assert_array_nanclose(expect_ihh0, ihh0)
+    assert_array_almost_equal(expect_ihh0, ihh0)
     expect_ihh1 = [np.nan, np.nan, x, x]
-    assert_array_nanclose(expect_ihh1, ihh1)
+    assert_array_almost_equal(expect_ihh1, ihh1)
 
     ihh0, ihh1 = ihh01_scan(h, gaps, min_ehh=0, include_edges=True)
     expect_ihh0 = [0, 10 * 2 / 3, x, x]
-    assert_array_nanclose(expect_ihh0, ihh0)
+    assert_array_almost_equal(expect_ihh0, ihh0)
     expect_ihh1 = [0, 10 * 2 / 3, x, x]
-    assert_array_nanclose(expect_ihh1, ihh1)
+    assert_array_almost_equal(expect_ihh1, ihh1)
 
 
 def test_ihh01_scan_e():
@@ -332,14 +332,14 @@ def test_ihh01_scan_e():
     expect_ihh0 = [0, 10, 20]
     expect_ihh1 = [np.nan, np.nan, np.nan]
     ihh0, ihh1 = ihh01_scan(h, gaps, min_ehh=0, min_maf=0, include_edges=True)
-    assert_array_nanclose(expect_ihh0, ihh0)
-    assert_array_nanclose(expect_ihh1, ihh1)
+    assert_array_almost_equal(expect_ihh0, ihh0)
+    assert_array_almost_equal(expect_ihh1, ihh1)
 
     expect_ihh0 = [np.nan, np.nan, np.nan]
     expect_ihh1 = [np.nan, np.nan, np.nan]
     ihh0, ihh1 = ihh01_scan(h, gaps, min_ehh=0, min_maf=0.4, include_edges=True)
-    assert_array_nanclose(expect_ihh0, ihh0)
-    assert_array_nanclose(expect_ihh1, ihh1)
+    assert_array_almost_equal(expect_ihh0, ihh0)
+    assert_array_almost_equal(expect_ihh1, ihh1)
 
 
 def test_ssl2ihh_a():
@@ -631,6 +631,6 @@ def test_pbs():
     assert 'f' == ret.dtype.kind
     # regression check
     expect = [0.52349464,  0., -0.85199356, np.nan]
-    assert_array_nanclose(expect, ret)
+    assert_array_almost_equal(expect, ret)
     # final value is nan because variants in final window are non-segregating
     assert np.isnan(ret[3])

--- a/allel/test/test_io_vcf_read.py
+++ b/allel/test/test_io_vcf_read.py
@@ -18,7 +18,7 @@ from nose.tools import (assert_almost_equal, eq_, assert_in, assert_list_equal,
                         assert_raises)
 from allel.io.vcf_read import (iter_vcf_chunks, read_vcf, vcf_to_zarr, vcf_to_hdf5,
                                vcf_to_npz, ANNTransformer, vcf_to_dataframe, vcf_to_csv,
-                               vcf_to_recarray)
+                               vcf_to_recarray, read_vcf_headers)
 from allel.compat import PY2
 from allel.test.tools import compare_arrays
 
@@ -2605,3 +2605,31 @@ def test_vcf_to_recarray_ann():
                     assert False, (k, e.ndim)
             else:
                 assert name not in a.dtype.names
+
+
+def test_read_vcf_headers():
+    vcf_path = os.path.join(os.path.dirname(__file__), 'data', 'sample.vcf')
+    headers = read_vcf_headers(vcf_path)
+
+    # check headers
+    assert_in('q10', headers.filters)
+    assert_in('s50', headers.filters)
+    assert_in('AA', headers.infos)
+    assert_in('AC', headers.infos)
+    assert_in('AF', headers.infos)
+    assert_in('AN', headers.infos)
+    assert_in('DB', headers.infos)
+    assert_in('DP', headers.infos)
+    assert_in('H2', headers.infos)
+    assert_in('NS', headers.infos)
+    assert_in('DP', headers.formats)
+    assert_in('GQ', headers.formats)
+    assert_in('GT', headers.formats)
+    assert_in('HQ', headers.formats)
+    eq_(['NA00001', 'NA00002', 'NA00003'], headers.samples)
+    eq_('1', headers.infos['AA']['Number'])
+    eq_('String', headers.infos['AA']['Type'])
+    eq_('Ancestral Allele', headers.infos['AA']['Description'])
+    eq_('2', headers.formats['HQ']['Number'])
+    eq_('Integer', headers.formats['HQ']['Type'])
+    eq_('Haplotype Quality', headers.formats['HQ']['Description'])

--- a/allel/test/test_io_vcf_read.py
+++ b/allel/test/test_io_vcf_read.py
@@ -88,8 +88,8 @@ def test_read_vcf_chunks():
         'variants/H2',
         'variants/NS',
         # special computed fields
+        'variants/altlen',
         'variants/numalt',
-        'variants/svlen',
         'variants/is_snp',
         # FORMAT fields
         'calldata/GT',
@@ -126,8 +126,8 @@ def test_fields_all():
         'variants/H2',
         'variants/NS',
         # special computed fields
+        'variants/altlen',
         'variants/numalt',
-        'variants/svlen',
         'variants/is_snp',
         # FORMAT fields
         'calldata/GT',
@@ -179,8 +179,8 @@ def test_fields_all_variants():
         'variants/H2',
         'variants/NS',
         # special computed fields
+        'variants/altlen',
         'variants/numalt',
-        'variants/svlen',
         'variants/is_snp',
     ]
     assert_list_equal(sorted(expected_fields), sorted(callset.keys()))
@@ -1594,7 +1594,7 @@ def test_computed_fields():
         eq_((9,), a.shape)
         assert_array_equal([0, 1, 0, 1, 2, 3, 2, 2, 5], a)
 
-        a = callset['variants/svlen']
+        a = callset['variants/altlen']
         eq_((9, 5), a.shape)
         e = np.array([[0, 0, 0, 0, 0],
                       [1, 0, 0, 0, 0],
@@ -1628,7 +1628,7 @@ def test_computed_fields():
         eq_((9,), a.shape)
         assert_array_equal([0, 1, 0, 1, 2, 3, 2, 2, 5], a)
 
-        a = callset['variants/svlen']
+        a = callset['variants/altlen']
         eq_((9,), a.shape)
         e = np.array([0, 1, 0, 0, 0, 0, 0, -3, 0])
         assert_array_equal(e, a)

--- a/allel/test/test_io_vcf_read.py
+++ b/allel/test/test_io_vcf_read.py
@@ -2144,7 +2144,7 @@ def test_vcf_to_zarr_dup_fields_case_insensitive():
     with assert_raises(ValueError):
         vcf_to_zarr(vcf_path, zarr_path, fields=['variants/ALTLEN', 'variants/altlen'])
     # should be fine if renamed
-    vcf_to_zarr(vcf_path, zarr_path, fields=['ALTLEN', 'altlen'], 
+    vcf_to_zarr(vcf_path, zarr_path, fields=['ALTLEN', 'altlen'],
                 rename_fields={'altlen': 'variants/spam'})
 
 

--- a/allel/test/test_stats.py
+++ b/allel/test/test_stats.py
@@ -7,8 +7,7 @@ import unittest
 
 import numpy as np
 from nose.tools import assert_raises, eq_ as eq
-from allel.test.tools import assert_array_equal as aeq, assert_array_close, \
-    assert_array_nanclose
+from allel.test.tools import assert_array_equal as aeq, assert_array_almost_equal
 
 
 import allel
@@ -181,7 +180,7 @@ class TestDiversityDivergence(unittest.TestCase):
         ac = h.count_alleles()
         expect = [0, 3/6, 4/6, 3/6, 0, 5/6, 5/6, 1, -1]
         actual = allel.mean_pairwise_difference(ac, fill=-1)
-        assert_array_close(expect, actual)
+        assert_array_almost_equal(expect, actual)
 
     def test_sequence_divergence(self):
         from allel import sequence_divergence
@@ -229,7 +228,7 @@ class TestDiversityDivergence(unittest.TestCase):
         pos = SortedIndex([2, 4, 7, 14, 15, 18, 19, 25, 27])
         expect = [(7/6)/10, (13/6)/10, 1/11]
         actual, _, _, _ = allel.windowed_diversity(pos, ac, size=10, start=1, stop=31)
-        assert_array_close(expect, actual)
+        assert_array_almost_equal(expect, actual)
 
     def test_mean_pairwise_divergence(self):
 
@@ -275,7 +274,7 @@ class TestDiversityDivergence(unittest.TestCase):
         actual, _, _, _ = allel.windowed_divergence(
             pos, ac1, ac2, size=10, start=1, stop=31
         )
-        assert_array_close(expect, actual)
+        assert_array_almost_equal(expect, actual)
 
 
 class TestHardyWeinberg(unittest.TestCase):
@@ -349,11 +348,11 @@ class TestHardyWeinberg(unittest.TestCase):
         af = g.count_alleles().to_frequencies()
         expect2 = refimpl(af, ploidy=g.ploidy, fill=-1)
         actual = allel.heterozygosity_expected(af, ploidy=g.ploidy, fill=-1)
-        assert_array_close(expect1, actual)
-        assert_array_close(expect2, actual)
+        assert_array_almost_equal(expect1, actual)
+        assert_array_almost_equal(expect2, actual)
         expect3 = [0, 0, 0.5, .375, .375, .375, .5, .625, 0, .5, 0]
         actual = allel.heterozygosity_expected(af, ploidy=g.ploidy, fill=0)
-        assert_array_close(expect3, actual)
+        assert_array_almost_equal(expect3, actual)
 
         # polyploid
         g = GenotypeArray([[[0, 0, 0], [0, 0, 0]],
@@ -370,7 +369,7 @@ class TestHardyWeinberg(unittest.TestCase):
         af = g.count_alleles().to_frequencies()
         expect = refimpl(af, ploidy=g.ploidy, fill=-1)
         actual = allel.heterozygosity_expected(af, ploidy=g.ploidy, fill=-1)
-        assert_array_close(expect, actual)
+        assert_array_almost_equal(expect, actual)
 
     def test_inbreeding_coefficient(self):
 
@@ -392,7 +391,7 @@ class TestHardyWeinberg(unittest.TestCase):
         expect = [-1, -1, 1-0, 1-(.5/.375), 1-(.5/.375), 1-(.5/.375),
                   1-(1/.5), 1-(1/.625), -1, 1-(1/.5), -1]
         actual = allel.inbreeding_coefficient(g, fill=-1)
-        assert_array_close(expect, actual)
+        assert_array_almost_equal(expect, actual)
 
 
 class TestDistance(unittest.TestCase):
@@ -559,7 +558,7 @@ class TestLinkageDisequilibrium(unittest.TestCase):
               [0, 1]]
         expect = [-1, 1, -1]
         actual = allel.rogers_huff_r(gn)
-        assert_array_close(expect, actual)
+        assert_array_almost_equal(expect, actual)
 
         gn = [[0, 2, 0],
               [0, 2, 0],
@@ -567,7 +566,7 @@ class TestLinkageDisequilibrium(unittest.TestCase):
               [0, 2, -1]]
         expect = [1, -1, 1, -1, 1, -1]
         actual = allel.rogers_huff_r(gn)
-        assert_array_close(expect, actual)
+        assert_array_almost_equal(expect, actual)
 
     def test_rogers_huff_r_between(self):
 
@@ -637,7 +636,7 @@ class TestAdmixture(unittest.TestCase):
                [0, 2]]
         expect = [0., 1., 0., np.nan]
         actual = allel.patterson_f2(aca, acb)
-        assert_array_nanclose(expect, actual)
+        assert_array_almost_equal(expect, actual)
 
     def test_patterson_f3(self):
         aca = [[0, 2],
@@ -657,9 +656,9 @@ class TestAdmixture(unittest.TestCase):
                [1, 1]]
         expect_f3 = [-.5, -.5, 0., 1., np.nan]
         actual_f3, actual_hzc = allel.patterson_f3(acc, aca, acb)
-        assert_array_nanclose(expect_f3, actual_f3)
+        assert_array_almost_equal(expect_f3, actual_f3)
         expect_hzc = [1., 1., 0., 0., 1.]
-        assert_array_nanclose(expect_hzc, actual_hzc)
+        assert_array_almost_equal(expect_hzc, actual_hzc)
 
     def test_patterson_d(self):
         aca = [[0, 2],
@@ -685,8 +684,8 @@ class TestAdmixture(unittest.TestCase):
         num, den = allel.patterson_d(aca, acb, acc, acd)
         expect_num = [0., 1., -1., 0., np.nan]
         expect_den = [0., 1., 1., 0.25, np.nan]
-        assert_array_nanclose(expect_num, num)
-        assert_array_nanclose(expect_den, den)
+        assert_array_almost_equal(expect_num, num)
+        assert_array_almost_equal(expect_den, den)
 
 
 class TestSF(unittest.TestCase):

--- a/allel/test/tools.py
+++ b/allel/test/tools.py
@@ -3,37 +3,32 @@ from __future__ import absolute_import, print_function, division
 
 
 import numpy as np
-from nose.tools import assert_true
+from numpy.testing import assert_array_equal, assert_array_almost_equal
 
 
-def assert_array_equal(expect, actual):
-    expect = np.asarray(expect[:])
-    actual = np.asarray(actual[:])
-    assert_true(
-        np.array_equal(expect, actual),
-        '\nExpect:\n%r\nActual:\n%r\n' % (expect, actual)
-    )
+def assert_array_items_equal(expect, actual):
+
+    assert expect.shape == actual.shape
+    assert expect.dtype == actual.dtype
+
+    # numpy asserts don't compare object arrays
+    # properly; assert that we have the same nans
+    # and values
+    actual = actual.ravel().tolist()
+    expect = expect.ravel().tolist()
+    for a, r in zip(actual, expect):
+        if isinstance(a, np.ndarray):
+            assert_array_equal(a, r)
+        elif a != a:
+            assert r != r
+        else:
+            assert a == r
 
 
-def assert_array_close(expect, actual):
-    expect = np.asarray(expect[:])
-    actual = np.asarray(actual[:])
-    assert_true(
-        np.allclose(expect, actual),
-        '\nExpect:\n%r\nActual:\n%r\n' % (expect, actual)
-    )
-
-
-def assert_array_nanclose(expect, actual):
-    expect = np.asarray(expect[:])
-    actual = np.asarray(actual[:])
-    ein = np.isnan(expect)
-    ain = np.isnan(actual)
-    assert_true(
-        np.array_equal(ein, ain),
-        '\nExpect isnan:\n%r\nActual isnan:\n%r\n' % (ein, ain)
-    )
-    assert_true(
-        np.allclose(expect[~ein], actual[~ain]),
-        '\nExpect:\n%r\nActual:\n%r\n' % (expect, actual)
-    )
+def compare_arrays(expected, actual):
+    if expected.dtype.kind == 'f':
+        assert_array_almost_equal(expected, actual)
+    elif expected.dtype.kind == 'O':
+        assert_array_items_equal(expected, actual)
+    else:
+        assert_array_equal(expected, actual)

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -13,27 +13,15 @@ environment:
 
   matrix:
 
-    - PYTHON: "C:\\Python27"
-      PYTHON_VERSION: "2.7"
-
     - PYTHON: "C:\\Python27-x64"
       PYTHON_VERSION: "2.7"
       DISTUTILS_USE_SDK: "1"
 
-    - PYTHON: "C:\\Python35"
-      PYTHON_VERSION: "3.5"
-
     - PYTHON: "C:\\Python35-x64"
       PYTHON_VERSION: "3.5"
 
-    - PYTHON: "C:\\Python36"
-      PYTHON_VERSION: "3.6"
-
     - PYTHON: "C:\\Python36-x64"
       PYTHON_VERSION: "3.6"
-
-    - PYTHON: "C:\\Python37"
-      PYTHON_VERSION: "3.7"
 
     - PYTHON: "C:\\Python37-x64"
       PYTHON_VERSION: "3.7"

--- a/docs/io.rst
+++ b/docs/io.rst
@@ -12,6 +12,7 @@ Variant Call Format (VCF)
 .. autofunction:: allel.vcf_to_csv
 .. autofunction:: allel.vcf_to_recarray
 .. autofunction:: allel.iter_vcf_chunks
+.. autofunction:: allel.read_vcf_headers
 .. autoclass:: allel.ANNTransformer
 .. autofunction:: allel.write_vcf
 

--- a/docs/release.rst
+++ b/docs/release.rst
@@ -9,6 +9,9 @@ v1.2.0 (work in progress)
   (`#215 <https://github.com/cggh/scikit-allel/issues/215>`_,
   `#216 <https://github.com/cggh/scikit-allel/issues/216>`_).
 
+* Added a convenience function :func:`allel.read_vcf_headers`, to obtain just
+  header information from a VCF file.
+
 
 v1.1.10
 -------

--- a/docs/release.rst
+++ b/docs/release.rst
@@ -1,6 +1,15 @@
 Release notes
 =============
 
+v1.2.0 (work in progress)
+-------------------------
+
+* Added new parameters ``exclude_fields`` and ``rename_fields`` to VCF parsing
+  functions to add greater flexibility when selecting fields to extract
+  (`#215 <https://github.com/cggh/scikit-allel/issues/215>`_,
+  `#216 <https://github.com/cggh/scikit-allel/issues/216>`_).
+
+
 v1.1.10
 -------
 


### PR DESCRIPTION
This PR implements several measures to mitigate against unexpected/cryptic errors that can occur when converting data from VCF to Zarr on platforms with a case-insensitive file system. Resolves #215.

The following measures are implemented:

* [x] Rename the computed field "svlen" to "altlen" to avoid clash with commonly used "SVLEN" INFO field (which means something a bit different anyway).
* [x] Add an argument ``exclude_fields`` to all VCF parsing functions to allow exclusion of specific fields, which can be a workaround if there is a name clash, and is generally useful anyway.
* [x] Add an argument ``rename_fields`` to all VCF parsing functions to allow renaming of fields for convenience and in case of a name clash.
* [x] Detect name clashes when converting to zarr and raise some kind of informative error.

Other TODOs:
* [x] Release notes.

There is also some general tidying of tests and code and minor refactoring to remove redundancy in this PR.