### PR TITLE
from_items  is deprecated. 

### DIFF
--- a/allel/io/vcf_read.py
+++ b/allel/io/vcf_read.py
@@ -10,7 +10,7 @@ from __future__ import absolute_import, print_function, division
 import gzip
 import os
 import re
-from collections import namedtuple, defaultdict
+from collections import namedtuple, defaultdict, OrderedDict
 import warnings
 import time
 import subprocess
@@ -1770,8 +1770,8 @@ def _chunk_to_dataframe(fields, chunk):
             for i in range(a.shape[1]):
                 items.append(('%s_%s' % (name, i + 1), a[:, i]))
         else:
-            warnings.warn('cannot handle array %r with >2 dimensions, skipping' % name)
-    df = pandas.DataFrame.from_items(items)
+            warnings.warn('cannot handle array %r with >2 dimensions, skipping' % name)   
+    df = pandas.DataFrame.from_dict(OrderedDict(items))
     # treat empty string as missing
     df.replace('', np.nan, inplace=True)
     return df


### PR DESCRIPTION
it could be useful to update it with from_dict.

BTW also extend the "dataframe" export to use also the "calldata" group could be useful.
I am working on such extensions (just a draft of the idea).
If someone is interested we can discuss about it.
The vcf parameter is the output of allel.read_vcf.

def vcf_to_dataframe(vcf):
    df = pd.DataFrame()    
    df['POS'] = vcf['variants/POS']
    df['CHROM'] = vcf['variants/CHROM']
    df['ID'] = vcf['variants/ID']
    df['REF'] = vcf['variants/REF']
    df['ALT_1'] = vcf['variants/ALT'][:,0]
    df['ALT_2'] = vcf['variants/ALT'][:,1]
    df['ALT_3'] = vcf['variants/ALT'][:,2]    
    for sample_index,sample in enumerate(vcf['samples']):
        gt_key = '%s_GT' % sample
        a1_key = "%s_GT_A1" % sample
        a2_key = "%s_GT_A2" % sample
        gp_key = "%s_GP" % sample
        df[a1_key] = vcf['calldata/GT'][:,sample_index,0]
        df[a2_key] = vcf['calldata/GT'][:,sample_index,1]
        if 'calldata/GP' in vcf.keys():        
            df[gp_key] = np.amax(vcf['calldata/GP'][:,sample_index],axis=1)
        df[gt_key] = df[a1_key] + df[a2_key]        
        alteredalt_index = df[df[gt_key] > 2].index
        df.loc[alteredalt_index,gt_key] = 2
    return df

