### PR TITLE
Implement ChromPosIndex

### DIFF
--- a/allel/test/model/ndarray/test_indexes.py
+++ b/allel/test/model/ndarray/test_indexes.py
@@ -10,9 +10,9 @@ import pytest
 
 # internal imports
 from allel.test.tools import assert_array_equal as aeq
-from allel import SortedIndex, UniqueIndex, SortedMultiIndex
+from allel import SortedIndex, UniqueIndex, SortedMultiIndex, ChromPosIndex
 from allel.test.model.test_api import SortedIndexInterface, UniqueIndexInterface, \
-    SortedMultiIndexInterface
+    SortedMultiIndexInterface, ChromPosIndexInterface
 
 
 # noinspection PyMethodMayBeStatic
@@ -153,3 +153,11 @@ class SortedMultiIndexTests(SortedMultiIndexInterface, unittest.TestCase):
         return SortedMultiIndex(chrom, pos)
 
     _class = SortedMultiIndex
+
+
+class ChromPosIndexTests(ChromPosIndexInterface, unittest.TestCase):
+
+    def setup_instance(self, chrom, pos):
+        return ChromPosIndex(chrom, pos)
+
+    _class = ChromPosIndex

--- a/allel/test/model/test_api.py
+++ b/allel/test/model/test_api.py
@@ -2277,6 +2277,66 @@ class SortedMultiIndexInterface(object):
             f(3, 2, 4)
 
 
+class ChromPosIndexInterface(object):
+
+    _class = None
+
+    def setup_instance(self, chrom, pos):
+        pass
+
+    def test_properties(self):
+        chrom = np.array([b'4', b'4', b'2', b'2', b'2', b'6'])
+        pos = np.array([1, 5, 3, 7, 7, 2])
+        idx = self.setup_instance(chrom, pos)
+        assert 6 == len(idx)
+
+    def test_locate_key(self):
+        chrom = np.array([b'4', b'4', b'2', b'2', b'2', b'6'])
+        pos = np.array([1, 5, 3, 7, 7, 2])
+        idx = self.setup_instance(chrom, pos)
+        f = idx.locate_key
+        assert slice(0, 2) == f(b'4')
+        assert slice(2, 5) == f(b'2')
+        assert slice(5, 6) == f(b'6')
+        assert 0 == f(b'4', 1)
+        assert 2 == f(b'2', 3)
+        assert 5 == f(b'6', 2)
+        assert slice(3, 5) == f(b'2', 7)
+        with pytest.raises(KeyError):
+            f(b'X')
+        with pytest.raises(KeyError):
+            f(b'4', 4)
+        with pytest.raises(KeyError):
+            f(b'2', 5)
+        with pytest.raises(KeyError):
+            f(b'6', 5)
+
+    def test_locate_range(self):
+        chrom = np.array([b'4', b'4', b'2', b'2', b'2', b'6'])
+        pos = np.array([1, 5, 3, 7, 7, 2])
+        idx = self.setup_instance(chrom, pos)
+        f = idx.locate_range
+
+        assert slice(0, 2) == f(b'4')
+        assert slice(2, 5) == f(b'2')
+        assert slice(5, 6) == f(b'6')
+        assert slice(0, 2) == f(b'4', 1, 5)
+        assert slice(0, 1) == f(b'4', 1, 3)
+        assert slice(2, 5) == f(b'2', 1, 9)
+        assert slice(2, 3) == f(b'2', 1, 6)
+        assert slice(5, 6) == f(b'6', 1, 6)
+        with pytest.raises(KeyError):
+            f(b'X')
+        with pytest.raises(KeyError):
+            f(b'4', 17, 19)
+        with pytest.raises(KeyError):
+            f(b'2', 1, 2)
+        with pytest.raises(KeyError):
+            f(b'2', 9, 12)
+        with pytest.raises(KeyError):
+            f(b'6', 3, 6)
+
+
 class VariantTableInterface(object):
 
     _class = None

--- a/docs/model/ndarray.rst
+++ b/docs/model/ndarray.rst
@@ -206,6 +206,14 @@ SortedIndex
     .. automethod:: intersect_ranges
 
 
+ChromPosIndex
+-------------
+
+.. autoclass:: allel.ChromPosIndex
+
+    .. automethod:: locate_key
+    .. automethod:: locate_range
+
 SortedMultiIndex
 ----------------
 

--- a/docs/release.rst
+++ b/docs/release.rst
@@ -31,6 +31,12 @@ v1.2.0 (work in progress)
   variants are returned. By :user:`Alistair Miles <alimanfoo>`,
   :issue:`221`, :issue:`167`, :issue:`213`.
 
+* Added a new index class :class:`allel.ChromPosIndex` for locating
+  data given chromosome and positio locations. This behaves similarly
+  to the existing :class:`allel.SortedMultiIndex` but the chromosome
+  values do not need to be sorted. By :user:`Alistair Miles
+  <alimanfoo>`, :issue:`201`, :issue:`239`.
+  
 * Added new parameters ``exclude_fields`` and ``rename_fields`` to VCF
   parsing functions to add greater flexibility when selecting fields
   to extract. Also added several measures to protect against name


### PR DESCRIPTION
This PR adds a new `ChromPosIndex` class for locating regions where you have data from multiple chromosomes concatenated together, but the chromosomes are not in sorted order.

Resolves #201.