### PR TITLE
Fix dtypes for allele counts

### DIFF
--- a/allel/model/dask.py
+++ b/allel/model/dask.py
@@ -382,7 +382,7 @@ class GenotypeDaskArray(GenotypesDask, DisplayAs2D):
                 return gb.count_alleles(max_allele=max_allele)[:, None, :]
 
             # map blocks and reduce
-            out = da.map_blocks(f, gd, chunks=chunks, dtype='i4').sum(axis=1)
+            out = da.map_blocks(f, gd, chunks=chunks).sum(axis=1, dtype='i4')
 
         else:
 
@@ -393,7 +393,7 @@ class GenotypeDaskArray(GenotypesDask, DisplayAs2D):
                 return g.count_alleles(max_allele=max_allele)[:, None, :]
 
             md = self.mask[:, :, None]
-            out = da.map_blocks(f, gd, md, chunks=chunks, dtype='i4').sum(axis=1)
+            out = da.map_blocks(f, gd, md, chunks=chunks).sum(axis=1, dtype='i4')
 
         return AlleleCountsDaskArray(out)
 
@@ -430,7 +430,7 @@ class GenotypeDaskArray(GenotypesDask, DisplayAs2D):
 
         # map blocks
         out = da.map_blocks(f, self.values, mapping[:, None, :], chunks=self.chunks,
-                            dtype=mapping.dtype)
+                            dtype=self.dtype)
         return type(self)(out)
 
     def to_allele_counts(self, max_allele=None):
@@ -602,8 +602,7 @@ class HaplotypeDaskArray(DaskArrayWrapper, DisplayAs2D):
             return h.count_alleles(max_allele=max_allele)[:, None, :]
 
         # map blocks and reduce
-        # TODO need to figure out dtype?
-        out = hd.map_blocks(f, chunks=chunks, new_axis=2).sum(axis=1)
+        out = hd.map_blocks(f, chunks=chunks, new_axis=2).sum(axis=1, dtype='i4')
         return AlleleCountsDaskArray(out)
 
     def count_alleles_subpops(self, subpops, max_allele=None):
@@ -625,7 +624,7 @@ class HaplotypeDaskArray(DaskArrayWrapper, DisplayAs2D):
         mapping = da.from_array(mapping, chunks=(self.chunks[0], None))
 
         # map blocks
-        out = da.map_blocks(f, self.values, mapping, chunks=self.chunks, dtype=mapping.dtype)
+        out = da.map_blocks(f, self.values, mapping, chunks=self.chunks, dtype=self.dtype)
         return HaplotypeDaskArray(out)
 
     def compress(self, condition, axis=0, out=None):
@@ -784,7 +783,7 @@ class AlleleCountsDaskArray(DaskArrayWrapper, DisplayAs2D):
             return ac.map_alleles(bmapping, max_allele=max_allele)
 
         # map blocks
-        out = da.map_blocks(f, self.values, mapping, dtype=mapping.dtype)
+        out = da.map_blocks(f, self.values, mapping, dtype=self.dtype)
         return AlleleCountsDaskArray(out)
 
     def compress(self, condition, axis=0, out=None):
@@ -979,7 +978,7 @@ class GenotypeAlleleCountsDaskArray(GenotypeAlleleCountsDask, DisplayAs2D):
         else:
             gd = self.values
 
-        out = gd.sum(axis=1)
+        out = gd.sum(axis=1, dtype='i4')
         return AlleleCountsDaskArray(out)
 
     def compress(self, condition, axis=0, out=None):

--- a/allel/model/ndarray.py
+++ b/allel/model/ndarray.py
@@ -3322,7 +3322,8 @@ class GenotypeAlleleCountsArray(GenotypeAlleleCounts, DisplayAs2D):
         else:
             g = self.values
 
-        out = g.sum(axis=1)
+        out = np.empty((g.shape[0], g.shape[2]), dtype='i4')
+        g.sum(axis=1, out=out)
         out = AlleleCountsArray(out)
         return out
 

--- a/allel/test/model/test_api.py
+++ b/allel/test/model/test_api.py
@@ -780,6 +780,7 @@ class GenotypeArrayInterface(object):
             aeq(expect, actual)
             assert 5 == actual.n_variants
             assert 3 == actual.n_alleles
+            assert np.dtype('i4') == actual.dtype
 
             # polyploid
             g = self.setup_instance(triploid_genotype_data, dtype=dtype)
@@ -791,6 +792,7 @@ class GenotypeArrayInterface(object):
             aeq(expect, actual)
             assert 4 == actual.n_variants
             assert 3 == actual.n_alleles
+            assert np.dtype('i4') == actual.dtype
 
     def test_count_alleles_subpop(self):
         for dtype in None, 'i1', 'i2', 'i4', 'i8':
@@ -810,6 +812,7 @@ class GenotypeArrayInterface(object):
                 aeq(expect, actual)
                 assert 5 == actual.n_variants
                 assert 3 == actual.n_alleles
+                assert np.dtype('i4') == actual.dtype
 
     def test_count_alleles_subpops(self):
         for dtype in None, 'i1', 'i2', 'i4', 'i8':
@@ -833,8 +836,10 @@ class GenotypeArrayInterface(object):
                 aeq(expect_sub2, actual['sub2'])
                 assert 5 == actual['sub1'].n_variants
                 assert 3 == actual['sub1'].n_alleles
+                assert np.dtype('i4') == actual['sub1'].dtype
                 assert 5 == actual['sub2'].n_variants
                 assert 3 == actual['sub2'].n_alleles
+                assert np.dtype('i4') == actual['sub2'].dtype
 
     def test_count_alleles_max_allele(self):
 
@@ -881,7 +886,7 @@ class GenotypeArrayInterface(object):
             aeq(expect[:, :1], actual)
 
     def test_map_alleles(self):
-        for dtype in None, 'i1', 'i2', 'i4', 'i8':
+        for dtype in 'i1', 'i2', 'i4', 'i8':
             a = np.array(diploid_genotype_data, dtype=dtype)
             g = self.setup_instance(a)
             mapping = np.array([[0, 1, 2],
@@ -896,6 +901,8 @@ class GenotypeArrayInterface(object):
                       [[-1, -1], [-1, -1], [-1, -1]]]
             actual = g.map_alleles(mapping)
             aeq(expect, actual)
+            # match input dtype
+            assert dtype == actual.dtype
 
     def test_set_mask(self):
 
@@ -1268,6 +1275,7 @@ class HaplotypeArrayInterface(object):
             aeq(expect, actual)
             assert 4 == actual.n_variants
             assert 3 == actual.n_alleles
+            assert np.dtype('i4') == actual.dtype
 
     def test_count_alleles_subpop(self):
         expect = np.array([[1, 0, 0],
@@ -1285,6 +1293,7 @@ class HaplotypeArrayInterface(object):
                 aeq(expect, actual)
                 assert 4 == actual.n_variants
                 assert 3 == actual.n_alleles
+                assert np.dtype('i4') == actual.dtype
 
     def test_count_alleles_subpops(self):
         expect_sub1 = np.array([[1, 0, 0],
@@ -1304,8 +1313,10 @@ class HaplotypeArrayInterface(object):
                 aeq(expect_sub2, actual['sub2'])
                 assert 4 == actual['sub1'].n_variants
                 assert 3 == actual['sub1'].n_alleles
+                assert np.dtype('i4') == actual['sub1'].dtype
                 assert 4 == actual['sub2'].n_variants
                 assert 3 == actual['sub2'].n_alleles
+                assert np.dtype('i4') == actual['sub2'].dtype
 
     def test_count_alleles_max_allele(self):
         expect = np.array([[1, 1, 0],
@@ -1342,12 +1353,13 @@ class HaplotypeArrayInterface(object):
         actual = h.map_alleles(mapping)
         aeq(expect, actual)
 
-        for dtype in None, 'i1', 'i2', 'i4', 'i8':
+        for dtype in 'i1', 'i2', 'i4', 'i8':
             a = np.array(haplotype_data, dtype=dtype)
             h = self.setup_instance(a)
             mapping = np.array(mapping, dtype=dtype)
             actual = h.map_alleles(mapping)
             aeq(expect, actual)
+            assert dtype == actual.dtype
 
     def test_concatenate(self):
         a = np.array(haplotype_data, dtype=np.int8)
@@ -1536,21 +1548,24 @@ class AlleleCountsArrayInterface(object):
         aeq(expect, actual)
 
     def test_map_alleles(self):
-        ac = self.setup_instance(allele_counts_data)
-        mapping = np.array([[0, 1, 2],
-                            [2, 0, 1],
-                            [1, 2, 0],
-                            [-1, 1, 0],
-                            [2, 0, 1],
-                            [0, 2, 1]])
-        expect = [[3, 1, 0],
-                  [2, 1, 1],
-                  [1, 1, 2],
-                  [2, 0, 0],
-                  [0, 0, 0],
-                  [0, 2, 1]]
-        actual = ac.map_alleles(mapping)
-        aeq(expect, actual)
+        for dtype in 'i2', 'i4', 'i8':
+            ac = self.setup_instance(np.array(allele_counts_data, dtype=dtype))
+            mapping = np.array([[0, 1, 2],
+                                [2, 0, 1],
+                                [1, 2, 0],
+                                [-1, 1, 0],
+                                [2, 0, 1],
+                                [0, 2, 1]])
+            expect = [[3, 1, 0],
+                      [2, 1, 1],
+                      [1, 1, 2],
+                      [2, 0, 0],
+                      [0, 0, 0],
+                      [0, 2, 1]]
+            actual = ac.map_alleles(mapping)
+            aeq(expect, actual)
+            # match dtype of input
+            assert dtype == actual.dtype
 
         # another test based on https://github.com/cggh/scikit-allel/issues/200
         ac = self.setup_instance([[10, 20, 30, 40],
@@ -1936,6 +1951,7 @@ class GenotypeAlleleCountsArrayInterface(object):
         aeq(expect, actual)
         assert 5 == actual.n_variants
         assert 3 == actual.n_alleles
+        assert np.dtype('i4') == actual.dtype
 
         # polyploid
         g = self.setup_instance(triploid_genotype_ac_data)
@@ -1947,6 +1963,7 @@ class GenotypeAlleleCountsArrayInterface(object):
         aeq(expect, actual)
         assert 4 == actual.n_variants
         assert 3 == actual.n_alleles
+        assert np.dtype('i4') == actual.dtype
 
     def test_count_alleles_subpop(self):
         g = self.setup_instance(diploid_genotype_ac_data)
@@ -1964,6 +1981,7 @@ class GenotypeAlleleCountsArrayInterface(object):
             aeq(expect, actual)
             assert 5 == actual.n_variants
             assert 3 == actual.n_alleles
+            assert np.dtype('i4') == actual.dtype
 
 
 class SortedIndexInterface(object):


### PR DESCRIPTION
Fixes some dtypes to be more consistent. Particularly, use 32-bit integer for all allele counts arrays. Resolves #172.