### PR TITLE
LD functions fill value

### DIFF
--- a/allel/stats/ld.py
+++ b/allel/stats/ld.py
@@ -13,7 +13,7 @@ from allel.opt.stats import gn_pairwise_corrcoef_int8, gn_pairwise2_corrcoef_int
     gn_locate_unlinked_int8
 
 
-def rogers_huff_r(gn, fill=np.nan):
+def rogers_huff_r(gn):
     """Estimate the linkage disequilibrium parameter *r* for each pair of
     variants using the method of Rogers and Huff (2008).
 
@@ -22,8 +22,6 @@ def rogers_huff_r(gn, fill=np.nan):
     gn : array_like, int8, shape (n_variants, n_samples)
         Diploid genotypes at biallelic variants, coded as the number of
         alternate alleles per call (i.e., 0 = hom ref, 1 = het, 2 = hom alt).
-    fill : float, optional
-        Value to use where r cannot be calculated.
 
     Returns
     -------
@@ -65,7 +63,7 @@ def rogers_huff_r(gn, fill=np.nan):
     gn = memoryview_safe(gn)
 
     # compute correlation coefficients
-    r = gn_pairwise_corrcoef_int8(gn, fill)
+    r = gn_pairwise_corrcoef_int8(gn)
 
     # convenience for singletons
     if r.size == 1:
@@ -74,7 +72,7 @@ def rogers_huff_r(gn, fill=np.nan):
     return r
 
 
-def rogers_huff_r_between(gna, gnb, fill=np.nan):
+def rogers_huff_r_between(gna, gnb):
     """Estimate the linkage disequilibrium parameter *r* for each pair of
     variants between the two input arrays, using the method of Rogers and
     Huff (2008).
@@ -84,8 +82,6 @@ def rogers_huff_r_between(gna, gnb, fill=np.nan):
     gna, gnb : array_like, int8, shape (n_variants, n_samples)
         Diploid genotypes at biallelic variants, coded as the number of
         alternate alleles per call (i.e., 0 = hom ref, 1 = het, 2 = hom alt).
-    fill : float, optional
-        Value to use where r cannot be calculated.
 
     Returns
     -------
@@ -101,7 +97,7 @@ def rogers_huff_r_between(gna, gnb, fill=np.nan):
     gnb = memoryview_safe(gnb)
 
     # compute correlation coefficients
-    r = gn_pairwise2_corrcoef_int8(gna, gnb, fill)
+    r = gn_pairwise2_corrcoef_int8(gna, gnb)
 
     # convenience for singletons
     if r.size == 1:

--- a/allel/test/test_stats.py
+++ b/allel/test/test_stats.py
@@ -635,7 +635,27 @@ class TestLinkageDisequilibrium(unittest.TestCase):
         assert expect == actual
 
         gn = [[0, 0, 0],
+              [0, 0, 0]]
+        actual = allel.rogers_huff_r(gn)
+        assert np.isnan(actual)
+
+        gn = [[0, 0, 0],
               [1, 1, 1]]
+        actual = allel.rogers_huff_r(gn)
+        assert np.isnan(actual)
+
+        gn = [[1, 1, 1],
+              [1, 1, 1]]
+        actual = allel.rogers_huff_r(gn)
+        assert np.isnan(actual)
+
+        gn = [[0, -1, 0],
+              [-1, 1, -1]]
+        actual = allel.rogers_huff_r(gn)
+        assert np.isnan(actual)
+
+        gn = [[0, 1, 0],
+              [-1, -1, -1]]
         actual = allel.rogers_huff_r(gn)
         assert np.isnan(actual)
 

--- a/docs/release.rst
+++ b/docs/release.rst
@@ -73,6 +73,12 @@ v1.2.0 (work in progress)
   was provided as a numpy array. By :user:`Alistair Miles
   <alimanfoo>`, :issue:`235`, :issue:`171`.
 
+* Removed `fill` option to LD functions :func:`allel.rogers_huff_r`
+  and :func:`allel.rogers_huff_r_between`, always use NaN where a
+  value cannot be calculated. Also added additional tests and check
+  for case where variants have no data. By :user:`Alistair Miles
+  <alimanfoo>`, :issue:`197`, :issue:`243`.
+  
 * Fixed `setup.py` so that installation of numpy prior to installation
   of scikit-allel is no longer required - numpy will be automatically
   installed as a dependency if not already installed. By


### PR DESCRIPTION
This PR simplifies some LD functions by removing `fill` as an option and always using NaN where a value cannot be calculated. Also adds some tests and checks for cases where NaN should be returned. Resolves #197.