### PR TITLE
Test and fix to avoid rename clashes when reading VCF

### DIFF
--- a/allel/io/vcf_read.py
+++ b/allel/io/vcf_read.py
@@ -112,15 +112,15 @@ def _do_rename(it, fields, rename_fields, headers):
     # check no duplicate values
     found = set()
     for v in rename_fields.values():
-        if v in found:
+        if v.lower() in found:
             raise ValueError('rename clash: {!r}'.format(v))
-        found.add(v)
+        found.add(v.lower())
 
     # check no parent clashes
     for v in rename_fields.values():
         segments = v.split('/')
         for i in range(1, len(segments)):
-            prefix = '/'.join(segments[:i])
+            prefix = '/'.join(segments[:i]).lower()
             if prefix in found:
                 raise ValueError('rename clash: {!r} versus {!r}'.format(v, prefix))
 

--- a/allel/io/vcf_read.py
+++ b/allel/io/vcf_read.py
@@ -109,6 +109,21 @@ def _chunk_iter_transform(it, transformers):
 
 def _do_rename(it, fields, rename_fields, headers):
 
+    # check no duplicate values
+    found = set()
+    for v in rename_fields.values():
+        if v in found:
+            raise ValueError('rename clash: {!r}'.format(v))
+        found.add(v)
+
+    # check no parent clashes
+    for v in rename_fields.values():
+        segments = v.split('/')
+        for i in range(1, len(segments)):
+            prefix = '/'.join(segments[:i])
+            if prefix in found:
+                raise ValueError('rename clash: {!r} versus {!r}'.format(v, prefix))
+
     # normalise keys
     rename_fields = {_normalize_field_prefix(k, headers): v
                      for k, v in rename_fields.items()}

--- a/allel/test/io/test_vcf_read.py
+++ b/allel/test/io/test_vcf_read.py
@@ -232,6 +232,13 @@ def test_fields_rename_clash():
     with pytest.raises(ValueError):
         read_vcf(vcf_path, fields='*', rename_fields=rename)
 
+    # rename two fields to the same path (case insensitive)
+    rename = {'CHROM': 'variants/chromosome',
+              'variants/altlen': 'spam/eggs',
+              'calldata/GT': 'SPAM/EGGS'}
+    with pytest.raises(ValueError):
+        read_vcf(vcf_path, fields='*', rename_fields=rename)
+
     # parent clash
     rename = {'CHROM': 'variants/chromosome',
               'variants/altlen': 'spam/eggs',
@@ -241,8 +248,22 @@ def test_fields_rename_clash():
 
     # parent clash
     rename = {'CHROM': 'variants/chromosome',
+              'variants/altlen': 'spam/eggs',
+              'calldata/GT': 'SPAM'}
+    with pytest.raises(ValueError):
+        read_vcf(vcf_path, fields='*', rename_fields=rename)
+
+    # parent clash
+    rename = {'CHROM': 'variants/chromosome',
               'variants/altlen': 'spam',
               'calldata/GT': 'spam/eggs'}
+    with pytest.raises(ValueError):
+        read_vcf(vcf_path, fields='*', rename_fields=rename)
+
+    # parent clash
+    rename = {'CHROM': 'variants/chromosome',
+              'variants/altlen': 'spam',
+              'calldata/GT': 'SPAM/EGGS'}
     with pytest.raises(ValueError):
         read_vcf(vcf_path, fields='*', rename_fields=rename)
 

--- a/allel/test/io/test_vcf_read.py
+++ b/allel/test/io/test_vcf_read.py
@@ -222,6 +222,31 @@ def test_fields_rename():
     assert sorted(expected_fields) == sorted(callset.keys())
 
 
+def test_fields_rename_clash():
+    vcf_path = fixture_path('sample.vcf')
+
+    # rename two fields to the same path
+    rename = {'CHROM': 'variants/chromosome',
+              'variants/altlen': 'spam/eggs',
+              'calldata/GT': 'spam/eggs'}
+    with pytest.raises(ValueError):
+        read_vcf(vcf_path, fields='*', rename_fields=rename)
+
+    # parent clash
+    rename = {'CHROM': 'variants/chromosome',
+              'variants/altlen': 'spam/eggs',
+              'calldata/GT': 'spam'}
+    with pytest.raises(ValueError):
+        read_vcf(vcf_path, fields='*', rename_fields=rename)
+
+    # parent clash
+    rename = {'CHROM': 'variants/chromosome',
+              'variants/altlen': 'spam',
+              'calldata/GT': 'spam/eggs'}
+    with pytest.raises(ValueError):
+        read_vcf(vcf_path, fields='*', rename_fields=rename)
+
+
 def test_fields_default():
     vcf_path = fixture_path('sample.vcf')
     callset = read_vcf(vcf_path)
@@ -2219,6 +2244,32 @@ def test_vcf_to_zarr_rename():
         assert 'variants/' + key in expected
     for key in actual['calldata'].keys():
         assert 'calldata/' + key in expected
+
+
+def test_vcf_to_zarr_rename_clash():
+    vcf_path = fixture_path('sample.vcf')
+    zarr_path = os.path.join(tempdir, 'sample.zarr')
+
+    # dup values
+    rename = {'CHROM': 'variants/chromosome',
+              'variants/altlen': 'spam/eggs',
+              'calldata/GT': 'spam/eggs'}
+    with pytest.raises(ValueError):
+        vcf_to_zarr(vcf_path, zarr_path, fields='*', rename_fields=rename)
+
+    # parent clash
+    rename = {'CHROM': 'variants/chromosome',
+              'variants/altlen': 'spam/eggs',
+              'calldata/GT': 'spam'}
+    with pytest.raises(ValueError):
+        vcf_to_zarr(vcf_path, zarr_path, fields='*', rename_fields=rename)
+
+    # parent clash
+    rename = {'CHROM': 'variants/chromosome',
+              'variants/altlen': 'spam',
+              'calldata/GT': 'spam/eggs'}
+    with pytest.raises(ValueError):
+        vcf_to_zarr(vcf_path, zarr_path, fields='*', rename_fields=rename)
 
 
 def test_vcf_to_zarr_dup_fields_case_insensitive():

--- a/docs/release.rst
+++ b/docs/release.rst
@@ -6,11 +6,14 @@ Release notes
 v1.2.0
 ------
 
-.. important:: Please note, use of the `allel.stats` namespace is
-    deprecated in this release, all functions from stats modules are
-    available from the root `allel` namespace, please access them from
-    there.
+.. important:: Use of the `allel.stats` namespace is deprecated in
+    this release, all functions from stats modules are available from
+    the root `allel` namespace, please access them from there.
 
+.. important:: Python 2.7 has had a stay of execution - this release
+    supports Python 2.7 and 3.5-3.7. However, support for Python 2.7
+    will definitely be removed in version 1.3.
+	       
 * Added a new function :func:`allel.pbs` which implements the
   Population Branching Statistic (PBS), a test for selection based on
   allel frequency differentiation between three populations. :issue:`210`.
@@ -22,10 +25,10 @@ v1.2.0
   :issue:`188`, :issue:`187`.
 
 * Added a workaround to ensure arrays passed into Cython functions are
-  safe to use as memoryviews, even when using distributed computing
-  systems like `dask.distributed` where data may be moved between
-  compute nodes and provided with a read-only flag set. :issue:`#208`,
-  :issue:`206`.
+  safe to use as memoryviews, which is required to avoid errors when
+  using distributed computing systems like `dask.distributed` where
+  data may be moved between compute nodes and passed with a read-only
+  flag set. :issue:`#208`, :issue:`206`.
 
 * Added support for parsing VCF files where the chromosomes are not in
   lexical sorted order. Also improved handling of cases where no
@@ -73,6 +76,9 @@ v1.2.0
 
 * Allow multiallelic variants in
   :func:`allel.ehh_decay`. :issue:`209`, :issue:`244`.
+
+* Added checks to raise appropriate errors if user tries to rename two
+  fields to the same name when reading VCF. :issue:`245`, :issue:`220`.
   
 * Fixed `setup.py` so that installation of numpy prior to installation
   of scikit-allel is no longer required - numpy will be automatically


### PR DESCRIPTION
Adds checks that renaming fields when reading VCF does not cause clashes. Resolves #220.