### PR TITLE
[WIP] Add Dask Implementation of PCA Functions

### DIFF
--- a/allel/stats/preprocessing.py
+++ b/allel/stats/preprocessing.py
@@ -4,10 +4,10 @@ from __future__ import absolute_import, print_function, division
 import numpy as np
 import dask.array as da
 
+
+
 from allel.compat import text_type
-
-
-# from allel.util import asarray_ndim
+from allel.util import asarray_ndim
 
 
 def get_scaler(scaler, copy, ploidy):
@@ -34,6 +34,10 @@ class StandardScaler(object):
         self.std_ = None
 
     def fit(self, gn):
+
+        # check input
+        gn = asarray_ndim(gn, 2)
+
         # find mean and scaling factor
         if type(gn) is da.Array:
             self.mean_ = da.mean(gn, axis=1, keepdims=True)
@@ -47,6 +51,8 @@ class StandardScaler(object):
     def transform(self, gn, copy=None):
 
         # check inputs
+        copy = copy if copy is not None else self.copy
+        gn = asarray_ndim(gn, 2, copy=copy)
         if not gn.dtype.kind == 'f':
             gn = gn.astype('f2')
 
@@ -71,7 +77,11 @@ class CenterScaler(object):
         self.std_ = None
 
     def fit(self, gn):
-        # find mean and scaling factor
+
+        # check input
+        gn = asarray_ndim(gn, 2)
+
+        # find mean
         if type(gn) is da.Array:
             self.mean_ = da.mean(gn, axis=1, keepdims=True)
         else:
@@ -80,7 +90,10 @@ class CenterScaler(object):
         return self
 
     def transform(self, gn, copy=None):
+
         # check inputs
+        copy = copy if copy is not None else self.copy
+        gn = asarray_ndim(gn, 2, copy=copy)
         if not gn.dtype.kind == 'f':
             gn = gn.astype('f2')
 
@@ -103,6 +116,10 @@ class PattersonScaler(object):
         self.std_ = None
 
     def fit(self, gn):
+
+        # check input
+        gn = asarray_ndim(gn, 2)
+
         # find mean
         if type(gn) is da.Array:
             self.mean_ = da.mean(gn, axis=1, keepdims=True)
@@ -119,7 +136,10 @@ class PattersonScaler(object):
         return self
 
     def transform(self, gn, copy=None):
+
         # check inputs
+        copy = copy if copy is not None else self.copy
+        gn = asarray_ndim(gn, 2, copy=copy)
         if not gn.dtype.kind == 'f':
             gn = gn.astype('f2')
 

--- a/allel/stats/preprocessing.py
+++ b/allel/stats/preprocessing.py
@@ -1,12 +1,13 @@
 # -*- coding: utf-8 -*-
 from __future__ import absolute_import, print_function, division
 
-
 import numpy as np
-
+import dask.array as da
 
 from allel.compat import text_type
-from allel.util import asarray_ndim
+
+
+# from allel.util import asarray_ndim
 
 
 def get_scaler(scaler, copy, ploidy):
@@ -33,23 +34,19 @@ class StandardScaler(object):
         self.std_ = None
 
     def fit(self, gn):
-
-        # check input
-        gn = asarray_ndim(gn, 2)
-
-        # find mean
-        self.mean_ = np.mean(gn, axis=1, keepdims=True)
-
-        # find scaling factor
-        self.std_ = np.std(gn, axis=1, keepdims=True)
+        # find mean and scaling factor
+        if type(gn) is da.Array:
+            self.mean_ = da.mean(gn, axis=1, keepdims=True)
+            self.std_ = da.std(gn, axis=1, keepdims=True)
+        else:
+            self.mean_ = np.mean(gn, axis=1, keepdims=True)
+            self.std_ = np.std(gn, axis=1, keepdims=True)
 
         return self
 
     def transform(self, gn, copy=None):
 
         # check inputs
-        copy = copy if copy is not None else self.copy
-        gn = asarray_ndim(gn, 2, copy=copy)
         if not gn.dtype.kind == 'f':
             gn = gn.astype('f2')
 
@@ -74,20 +71,16 @@ class CenterScaler(object):
         self.std_ = None
 
     def fit(self, gn):
-
-        # check input
-        gn = asarray_ndim(gn, 2)
-
-        # find mean
-        self.mean_ = np.mean(gn, axis=1, keepdims=True)
+        # find mean and scaling factor
+        if type(gn) is da.Array:
+            self.mean_ = da.mean(gn, axis=1, keepdims=True)
+        else:
+            self.mean_ = np.mean(gn, axis=1, keepdims=True)
 
         return self
 
     def transform(self, gn, copy=None):
-
         # check inputs
-        copy = copy if copy is not None else self.copy
-        gn = asarray_ndim(gn, 2, copy=copy)
         if not gn.dtype.kind == 'f':
             gn = gn.astype('f2')
 
@@ -110,24 +103,23 @@ class PattersonScaler(object):
         self.std_ = None
 
     def fit(self, gn):
-
-        # check input
-        gn = asarray_ndim(gn, 2)
-
         # find mean
-        self.mean_ = np.mean(gn, axis=1, keepdims=True)
+        if type(gn) is da.Array:
+            self.mean_ = da.mean(gn, axis=1, keepdims=True)
+        else:
+            self.mean_ = np.mean(gn, axis=1, keepdims=True)
 
         # find scaling factor
         p = self.mean_ / self.ploidy
-        self.std_ = np.sqrt(p * (1 - p))
+        if type(gn) is da.Array:
+            self.std_ = da.sqrt(p * (1 - p))
+        else:
+            self.std_ = np.sqrt(p * (1 - p))
 
         return self
 
     def transform(self, gn, copy=None):
-
         # check inputs
-        copy = copy if copy is not None else self.copy
-        gn = asarray_ndim(gn, 2, copy=copy)
         if not gn.dtype.kind == 'f':
             gn = gn.astype('f2')
 

--- a/allel/util.py
+++ b/allel/util.py
@@ -8,6 +8,7 @@ import os
 
 import numpy as np
 
+import dask.array as da
 
 from allel.compat import string_types
 
@@ -49,7 +50,12 @@ def asarray_ndim(a, *ndims, **kwargs):
     kwargs.setdefault('copy', False)
     if a is None and allow_none:
         return None
-    a = np.array(a, **kwargs)
+    if type(a) is da.Array:
+        # Remove copy kwarg if it exists (Dask does not support this parameter)
+        kwargs.pop('copy', False)
+        a = da.array(a, **kwargs)
+    else:
+        a = np.array(a, **kwargs)
     if a.ndim not in ndims:
         if len(ndims) > 1:
             expect_str = 'one of %s' % str(ndims)


### PR DESCRIPTION
Hi @alimanfoo,

I have been working on adding the Dask implementations of [SVD](http://docs.dask.org/en/latest/array-api.html#dask.array.linalg.svd) and [randomized SVD](http://docs.dask.org/en/latest/array-api.html#dask.array.linalg.svd_compressed) to scikit-allel, and I wanted to post my current progress on here for feedback and suggestions.

This PR adds the ability to use the Dask versions of these functions whenever using Dask arrays (i.e. `DaskGenotypeArray`), and it will fall back to using numpy svd functions otherwise (when using `ChunkedGenotypeArray` or `GenotypeArray`, for example).

cc @ebegoli 