### PR TITLE
gametic heterozygosity_observed

### DIFF
--- a/allel/stats/hw.py
+++ b/allel/stats/hw.py
@@ -6,7 +6,7 @@ from allel.model.ndarray import GenotypeArray
 from allel.util import ignore_invalid, asarray_ndim
 
 
-def heterozygosity_observed(g, fill=np.nan):
+def heterozygosity_observed(g, fill=np.nan, corrected=True):
     """Calculate the rate of observed heterozygosity for each variant.
 
     Parameters
@@ -16,6 +16,8 @@ def heterozygosity_observed(g, fill=np.nan):
         Genotype array.
     fill : float, optional
         Use this value for variants where all calls are missing.
+    corrected : bool, optional
+        If True, values are corrected for ploidy level.
 
     Returns
     -------
@@ -23,8 +25,21 @@ def heterozygosity_observed(g, fill=np.nan):
     ho : ndarray, float, shape (n_variants,)
         Observed heterozygosity
 
+    Notes
+    -----
+
+    Observed heterozygosity is calculated assuming polysomic inheritance
+    for polyploid genotype arrays following Hardy (2015) (also see Meirmans
+    and Liu 2018).
+    By default, observed heterozygosity is corrected for ploidy by
+    *Ho = Hu * (ploidy / (ploidy - 1))* where *Ho* is the corrected observed
+    heterozygosity and *Hu* is the uncorrected observed heterozygosity
+    described by Meirmans and Liu (2018).
+
     Examples
     --------
+
+    Diploid genotype array
 
     >>> import allel
     >>> g = allel.GenotypeArray([[[0, 0], [0, 0], [0, 0]],
@@ -34,20 +49,53 @@ def heterozygosity_observed(g, fill=np.nan):
     >>> allel.heterozygosity_observed(g)
     array([0.        , 0.33333333, 0.        , 0.5       ])
 
+
+    Tetraploid genotype array
+
+    >>> import allel
+    >>> g = allel.GenotypeArray([[[0, 0, 0, 0], [0, 0, 0, 0]],
+    ...                          [[0, 0, 0, 0], [0, 0, 0, 1]],
+    ...                          [[0, 0, 1, 1], [0, 0, -1, -1]],
+    ...                          [[0, 1, 2, 3], [-1, -1, -1, -1]]])
+    >>> allel.heterozygosity_observed(g)
+    array([0.        , 0.25      , 0.75      , 0.66666667, 1.        ])
+
     """
 
     # check inputs
-    if not hasattr(g, 'count_het') or not hasattr(g, 'count_called'):
+    attrs = ['count_called', 'count_het', 'is_missing', 'to_allele_counts']
+    if not all(hasattr(g, attr) for attr in attrs):
         g = GenotypeArray(g, copy=False)
 
-    # count hets
-    n_het = np.asarray(g.count_het(axis=1))
+    ploidy = np.shape(g)[-1]
     n_called = np.asarray(g.count_called(axis=1))
+
+    # faster code path for most common case
+    if corrected and ploidy == 2:
+
+        # count hets
+        sum_het = np.asarray(g.count_het(axis=1))
+
+    else:
+
+        # sample allele frequencies with partial genotypes removed
+        saf = g.to_allele_counts().to_frequencies()
+        saf[g.is_missing()] = np.nan
+
+        # correction for ploidy level
+        with ignore_invalid():
+            correction = ploidy / (ploidy - 1) if corrected else 1
+
+        # matrix of observed heterozygosity per sample
+        hi = (1 - np.sum(np.power(saf, 2), axis=-1)) * correction
+
+        # sum individual heterozygosity
+        sum_het = np.nansum(hi, axis=-1)
 
     # calculate rate of observed heterozygosity, accounting for variants
     # where all calls are missing
     with ignore_invalid():
-        ho = np.where(n_called > 0, n_het / n_called, fill)
+        ho = np.where(n_called > 0, sum_het / n_called, fill)
 
     return ho
 

--- a/allel/stats/hw.py
+++ b/allel/stats/hw.py
@@ -29,7 +29,7 @@ def heterozygosity_observed(g, fill=np.nan, corrected=True):
     -----
 
     Observed heterozygosity is calculated assuming polysomic inheritance
-    for polyploid genotype arrays following Hardy (2015) (also see Meirmans
+    for polyploid genotype arrays following Hardy (2016) (also see Meirmans
     and Liu 2018).
     By default, observed heterozygosity is corrected for ploidy by
     *Ho = Hu * (ploidy / (ploidy - 1))* where *Ho* is the corrected observed

--- a/allel/test/test_stats.py
+++ b/allel/test/test_stats.py
@@ -403,7 +403,17 @@ class TestHardyWeinberg(unittest.TestCase):
         actual = allel.heterozygosity_observed(g, fill=-1)
         aeq(expect, actual)
 
-        # polyploid
+        # diploid uncorrected
+        # corrected is uncorrected * (2/1)
+        expect = [i / 2 if i >= 0 else i for i in expect]
+        actual = allel.heterozygosity_observed(g, fill=-1, corrected=False)
+        assert_array_almost_equal(expect, actual)
+
+        # triploid
+        # individual heterozygosity (Hi)
+        # dosage of 3:0:0 = Hi of 0/3
+        # dosage of 2:1:0 = Hi of 2/3
+        # dosage of 1:1:1 = Hi of 3/3
         g = GenotypeArray([[[0, 0, 0], [0, 0, 0]],
                            [[1, 1, 1], [1, 1, 1]],
                            [[1, 1, 1], [2, 2, 2]],
@@ -415,9 +425,15 @@ class TestHardyWeinberg(unittest.TestCase):
                            [[0, 0, 0], [-1, -1, -1]],
                            [[0, 0, 1], [-1, -1, -1]],
                            [[-1, -1, -1], [-1, -1, -1]]], dtype='i1')
-        expect = [0, 0, 0, .5, .5, .5, 1, 1, 0, 1, -1]
+        expect = [0, 0, 0, 1/3, 1/3, 3/6, 4/6, 5/6, 0, 2/3, -1]
         actual = allel.heterozygosity_observed(g, fill=-1)
-        aeq(expect, actual)
+        assert_array_almost_equal(expect, actual)
+
+        # triploid uncorrected
+        # corrected is uncorrected * (3/2)
+        expect = [i / (3/2) if i >= 0 else i for i in expect]
+        actual = allel.heterozygosity_observed(g, fill=-1, corrected=False)
+        assert_array_almost_equal(expect, actual)
 
     def test_heterozygosity_expected(self):
 

--- a/allel/test/test_stats.py
+++ b/allel/test/test_stats.py
@@ -435,6 +435,27 @@ class TestHardyWeinberg(unittest.TestCase):
         actual = allel.heterozygosity_observed(g, fill=-1, corrected=False)
         assert_array_almost_equal(expect, actual)
 
+        # hexaploid
+        # individual heterozygosity values from Hardy 2016
+        g = GenotypeArray([[[0, 0, 0, 0, 0, 0]],  # 6
+                           [[0, 0, 0, 0, 0, 1]],  # 5:1
+                           [[0, 0, 0, 0, 1, 1]],  # 4:2
+                           [[0, 0, 0, 1, 1, 1]],  # 3:3
+                           [[0, 0, 0, 0, 1, 2]],  # 4:1:1
+                           [[0, 1, 2, 2, 2, 2]],  # 4:1:1
+                           [[0, 0, 1, 1, 2, 2]],  # 2:2:2
+                           [[0, 0, 1, 2, 3, 4]],  # 2:1:1:1:1
+                           [[0, 0, 0, 1, 1, 2]]]) # 3:2:1
+        expect = [0 , 5/15, 8/15, 9/15, 9/15, 9/15, 12/15, 14/15, 11/15]
+        actual = allel.heterozygosity_observed(g, fill=0)
+        assert_array_almost_equal(expect, actual)
+
+        # hexaploid uncorrected
+        # corrected is uncorrected * (6/5)
+        expect = [i / (6/5) for i in expect]
+        actual = allel.heterozygosity_observed(g, fill=-1, corrected=False)
+        assert_array_almost_equal(expect, actual)
+
     def test_heterozygosity_expected(self):
 
         def refimpl(f, ploidy, fill=0):


### PR DESCRIPTION
See #277 for earlier discussion 

This updates `heterozygosity_observed` to use "gametic heterozygosity" which assumes polysomic inheritance (i.e. autopolyploidy).
Gametic heterozygosity is identical to the existing calculation (Nei's method) for the diploid case but generalises it to autopolyploids.

This implementation follows [Hardy 2016](https://onlinelibrary.wiley.com/doi/full/10.1111/1755-0998.12431) and [Meirmans and Liu 2018](https://www.frontiersin.org/articles/10.3389/fevo.2018.00066/full).

An additional argument `corrected` is added which defaults to `True` to correct for the ploidy level.
If this is set to `False` uncorrected Ho is calculated which is discussed in [Meirmans and Liu 2018](https://www.frontiersin.org/articles/10.3389/fevo.2018.00066/full) for comparing across ploidy levels.


Note that the existing code is used as a special case for diploids because it is faster - not because it produces a different result.

I updated the triploid test case though I'm not entirely sure about the applicability to odd-numbered ploidy levels. 