### PR TITLE
Adressing is_accessible problem in roh_mhmm, issue #296

### DIFF
--- a/allel/stats/roh.py
+++ b/allel/stats/roh.py
@@ -70,7 +70,7 @@ def roh_mhmm(gv, pos, phet_roh=0.001, phet_nonroh=(0.0025, 0.01), transition=1e-
     gv = GenotypeVector(gv)
     pos = asarray_ndim(pos, 1)
     check_dim0_aligned(gv, pos)
-    is_accessible = asarray_ndim(is_accessible, 1, dtype=bool)
+    is_accessible = asarray_ndim(is_accessible, 1, dtype=bool, allow_none=True)
 
     # heterozygote probabilities
     het_px = np.concatenate([(phet_roh,), phet_nonroh])

--- a/allel/test/test_stats.py
+++ b/allel/test/test_stats.py
@@ -814,6 +814,7 @@ class TestAdmixture(unittest.TestCase):
         assert_array_almost_equal(expect_num, num)
         assert_array_almost_equal(expect_den, den)
 
+
 class TestRunsOfHomozygosity(unittest.TestCase):
 
     def test_roh_mhmm_100pct(self):
@@ -834,4 +835,3 @@ class TestRunsOfHomozygosity(unittest.TestCase):
         roh, fraction = allel.roh_mhmm(gv, pos, contig_size=100)
         assert len(roh.values) == 0
         assert fraction == fraction_expected
-

--- a/allel/test/test_stats.py
+++ b/allel/test/test_stats.py
@@ -813,3 +813,25 @@ class TestAdmixture(unittest.TestCase):
         expect_den = [0., 1., 1., 0.25, np.nan]
         assert_array_almost_equal(expect_num, num)
         assert_array_almost_equal(expect_den, den)
+
+class TestRunsOfHomozygosity(unittest.TestCase):
+
+    def test_roh_mhmm_100pct(self):
+        roh_expected = np.array([[1, 100, 100, True]], dtype=object)
+        fraction_expected = 1.0
+        gv = [[0, 0, 0, 0], [0, 0, 0, 0]]
+        gv = np.transpose(gv)
+        pos = [1, 10, 50, 100]
+        roh, fraction = allel.roh_mhmm(gv, pos, contig_size=100)
+        aeq(roh.values, roh_expected)
+        assert fraction == fraction_expected
+
+    def test_roh_mhmm_0pct(self):
+        fraction_expected = 0.0
+        gv = [[0, 0, 1, 0], [0, 0, 0, 0]]
+        gv = np.transpose(gv)
+        pos = [1, 10, 50, 100]
+        roh, fraction = allel.roh_mhmm(gv, pos, contig_size=100)
+        assert len(roh.values) == 0
+        assert fraction == fraction_expected
+


### PR DESCRIPTION
As discussed in #296.

By using `allow_none=True` in call to `is_accessible()` in `roh_mhmm()` [line 73](https://github.com/olavurmortensen/scikit-allel/blob/45fb88c98f6b12bf0248b035cc4b5f1ed2e1b473/allel/stats/roh.py#L73), `_mhmm_predict_roh_state()` will simply skip masking inaccessible regions. This is the intended functionality when supplying `contig_size` but not `is_accessible`.

I also added unit tests of `roh_mhmm()` (was not able to find these anywhere) in the simple case of supplying a genotype list, position list, and contig size. Does not test other functionality of `roh_mhmm()`, nor does it test other ROH functions.