### PR TITLE
Fixed Issue #271: Added pathlib.Path support for functions taking a filepath

### DIFF
--- a/allel/io/fasta.py
+++ b/allel/io/fasta.py
@@ -36,7 +36,7 @@ def write_fasta(path, sequences, names, mode='w', width=80):
     mode = 'ab' if 'a' in mode else 'wb'
 
     # write to file
-    with open(path, mode=mode) as fasta:
+    with open(str(path), mode=mode) as fasta:
         for name, sequence in zip(names, sequences):
             # force bytes
             if isinstance(name, str):

--- a/allel/io/gff.py
+++ b/allel/io/gff.py
@@ -31,7 +31,7 @@ def iter_gff3(path, attributes=None, region=None, score_fill=-1,
 
     Parameters
     ----------
-    path : string
+    path : string or pathlib.Path
         Path to input file.
     attributes : list of strings, optional
         List of columns to extract from the "attributes" field.
@@ -64,6 +64,7 @@ def iter_gff3(path, attributes=None, region=None, score_fill=-1,
             attributes_fill = [attributes_fill] * len(attributes)
 
     # open input stream
+    path = str(path)
     if region is not None:
         cmd = [tabix, path, region]
         buffer = subprocess.Popen(cmd, stdout=subprocess.PIPE).stdout

--- a/allel/io/vcf_read.py
+++ b/allel/io/vcf_read.py
@@ -15,7 +15,7 @@ import time
 import subprocess
 import textwrap
 from collections import OrderedDict
-
+from pathlib import Path
 
 import numpy as np
 
@@ -1012,6 +1012,10 @@ def _setup_input_stream(input, region=None, tabix=None, buffer_size=DEFAULT_BUFF
 
     # obtain a file-like object
     close = False
+
+    if isinstance(input, Path):
+        input = str(input)
+
     if isinstance(input, str) and input.endswith('gz'):
 
         if region and tabix and os.name != 'nt':

--- a/allel/io/vcf_write.py
+++ b/allel/io/vcf_write.py
@@ -5,7 +5,6 @@ import itertools
 from operator import itemgetter
 import logging
 
-
 import numpy as np
 
 
@@ -50,7 +49,7 @@ def write_vcf(path, callset, rename=None, number=None, description=None,
 
     names, callset = normalize_callset(callset)
 
-    with open(path, 'w') as vcf_file:
+    with open(str(path), 'w') as vcf_file:
         if write_header:
             write_vcf_header(vcf_file, names, callset=callset, rename=rename,
                              number=number, description=description)


### PR DESCRIPTION
Modified `allel.io` functions taking a filepath to also accept `pathlib.Path`. By this change, anywhere a `string` is expected as filepath, a `pathlib.Path` instance can be accepted.