### PR TITLE
Drop Python 3.6 in CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,9 +9,9 @@ sudo: true
 dist: xenial
 
 python:
-  - "3.6"
   - "3.7"
   - "3.8"
+  - "3.9"
 
 install:
   - pip install -U pip setuptools wheel tox-travis coveralls

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -13,14 +13,14 @@ environment:
 
   matrix:
 
-    - PYTHON: "C:\\Python36-x64"
-      PYTHON_VERSION: "3.6"
-
     - PYTHON: "C:\\Python37-x64"
       PYTHON_VERSION: "3.7"
 
     - PYTHON: "C:\\Python38-x64"
       PYTHON_VERSION: "3.8"
+
+    - PYTHON: "C:\\Python39-x64"
+      PYTHON_VERSION: "3.9"
 
 install:
   - "SET PATH=%PYTHON%;%PYTHON%\\Scripts;%PATH%"

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = py36, py37, py38, docs
+envlist = py37, py38, py39, docs
 # trick to enable pre-installation of numpy and cython
 indexserver =
     preinstall = https://pypi.python.org/simple
@@ -15,10 +15,10 @@ setenv =
     PYTHONHASHSEED = 42
 commands =
     python setup.py build_ext --inplace
-    py36,py37: pytest -v --cov=allel allel
-    py38: pytest -v --cov=allel --doctest-modules allel
+    py37,py38: pytest -v --cov=allel allel
+    py39: pytest -v --cov=allel --doctest-modules allel
     coverage report -m
-    py38: flake8 allel --max-line-length=100
+    py39: flake8 allel --max-line-length=100
     pip freeze
 deps =
     :preinstall: setuptools
@@ -28,7 +28,7 @@ deps =
 
 [testenv:docs]
 install_command = pip install -U --no-cache-dir {opts} {packages}
-basepython = python3.7
+basepython = python3.8
 deps = -rrequirements_rtfd.txt
 commands =
     python setup.py install


### PR DESCRIPTION
Upstream dependencies have dropped support for Python 3.6, also drop here.