### PR TITLE
Fix #397 by specifying name and dynamic version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,7 @@
 [project]
 name = "scikit-allel"
 requires-python = ">=3.6"
+dynamic = ["version", "description"]
 
 [build-system]
 # Minimum requirements for the build system to execute.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,4 +1,5 @@
 [project]
+name = "scikit-allel"
 requires-python = ">=3.6"
 
 [build-system]


### PR DESCRIPTION
looks like pyproject.toml is not PEP621 compliant and therefore causing some trouble when installing it on some machines. Specified the project name and the version as described in [here](https://packaging.python.org/en/latest/specifications/declaring-project-metadata/)