### PR TITLE
Properly fix unpickling recursion

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -69,3 +69,6 @@ temp/*
 
 # setuptools-scm
 allel/version.py
+
+# VScode
+.vscode

--- a/allel/abc.py
+++ b/allel/abc.py
@@ -14,12 +14,6 @@ class ArrayWrapper(object):
             raise TypeError('values must be array-like')
         self._values = data
 
-    def __getstate__(self):
-        return self._values
-
-    def __setstate__(self, state):
-        self._values = state
-
     @property
     def values(self):
         """The underlying array of values.
@@ -40,10 +34,14 @@ class ArrayWrapper(object):
 
     def __getattr__(self, item):
         if item in {'__array_struct__', '__array_interface__'}:
-            # don't pass these through because we want to use __array__ to control numpy
-            # behaviour
-            raise AttributeError
-        return getattr(self.values, item)
+            # Don't pass these through because we want to use __array__ to control numpy
+            # behaviour.
+            raise AttributeError(item)
+        if item == "__setstate__":
+            # Special method called during unpickling, don't pass through.
+            raise AttributeError(item)
+        # Pass through all other attribute access to the wrapped values.
+        return getattr(self._values, item)
 
     def __getitem__(self, item):
         return self.values[item]

--- a/allel/test/model/ndarray/test_arrays.py
+++ b/allel/test/model/ndarray/test_arrays.py
@@ -146,9 +146,18 @@ class GenotypeArrayTests(GenotypeArrayInterface, unittest.TestCase):
 
     def test_pickle(self):
         g = self.setup_instance(diploid_genotype_data)
-        g2 = pickle.loads(pickle.dumps(g))
+        s = pickle.dumps(g)
+        g2 = pickle.loads(s)
         assert isinstance(g2, GenotypeArray)
         aeq(g, g2)
+        gn = g2.to_n_alt()
+        assert isinstance(gn, np.ndarray)
+        ac = g2.count_alleles(max_allele=1)
+        assert isinstance(ac, AlleleCountsArray)
+        h = g2.to_haplotypes()
+        assert isinstance(h, HaplotypeArray)
+        gac = g2.to_allele_counts(max_allele=1)
+        assert isinstance(gac, GenotypeAlleleCountsArray)
 
 
 # noinspection PyMethodMayBeStatic
@@ -223,6 +232,10 @@ class HaplotypeArrayTests(HaplotypeArrayInterface, unittest.TestCase):
         h2 = pickle.loads(pickle.dumps(h))
         assert isinstance(h2, HaplotypeArray)
         aeq(h, h2)
+        ac = h2.count_alleles(max_allele=1)
+        assert isinstance(ac, AlleleCountsArray)
+        gt = h2.to_genotypes(ploidy=3)
+        assert isinstance(gt, GenotypeArray)
 
 
 # noinspection PyMethodMayBeStatic
@@ -392,6 +405,11 @@ class GenotypeVectorTests(unittest.TestCase):
         gs = gv[np.newaxis, :2, 0]  # change dimension semantics
         assert not isinstance(gs, GenotypeVector)
 
+    def test_pickle(self):
+        gv = GenotypeVector(diploid_genotype_data[0])
+        gv2 = pickle.loads(pickle.dumps(gv))
+        aeq(gv, gv2)
+
     # __getitem__
     # to_html_str
     # _repr_html_
@@ -497,3 +515,8 @@ class GenotypeAlleleCountsArrayTests(GenotypeAlleleCountsArrayInterface, unittes
         s = g[0, 0, 0]
         assert isinstance(s, np.int8)
         assert not isinstance(s, GenotypeAlleleCountsArray)
+
+    def test_pickle(self):
+        g = GenotypeAlleleCountsArray(diploid_genotype_ac_data, dtype='i1')
+        g2 = pickle.loads(pickle.dumps(g))
+        aeq(g, g2)


### PR DESCRIPTION
This PR properly addresses the recursion problems previously encountered in #424 and attempted to fix in #425.

The original recursion issue was caused because during unpickling `getattr(self, "__setstate__")` is called if the object does not implement `__setstate__`. This is not something we want to pass through to the wrapped inner object, so this PR handles this case specifically and ensures an `AttributeError` is raised. 